### PR TITLE
Implement `--errors` for `ghcid.txt`

### DIFF
--- a/src/clap/camino.rs
+++ b/src/clap/camino.rs
@@ -24,7 +24,8 @@ impl TypedValueParser for Utf8PathBufValueParser {
                 clap::Error::raw(
                     clap::error::ErrorKind::InvalidUtf8,
                     format!("Path isn't UTF-8: {path_buf:?}"),
-                ).with_cmd(cmd)
+                )
+                .with_cmd(cmd)
             })
         })
     }

--- a/src/clap/humantime.rs
+++ b/src/clap/humantime.rs
@@ -5,8 +5,6 @@ use std::time::Duration;
 use clap::builder::StringValueParser;
 use clap::builder::TypedValueParser;
 use clap::builder::ValueParserFactory;
-use clap::error::ContextKind;
-use clap::error::ContextValue;
 use humantime::DurationError;
 use miette::LabeledSpan;
 use miette::MietteDiagnostic;

--- a/src/clap/mod.rs
+++ b/src/clap/mod.rs
@@ -5,6 +5,6 @@ mod error_message;
 mod humantime;
 mod rust_backtrace;
 
-pub use rust_backtrace::RustBacktrace;
 pub use self::humantime::DurationValueParser;
 pub use error_message::value_validation_error;
+pub use rust_backtrace::RustBacktrace;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,10 @@ pub struct Opts {
     #[arg(long)]
     pub test: Option<String>,
 
+    /// A file to write compilation errors to. This is analogous to `ghcid.txt`.
+    #[arg(long)]
+    pub errors: Option<Utf8PathBuf>,
+
     /// Options to modify file watching.
     #[command(flatten)]
     pub watch: WatchOpts,
@@ -80,8 +84,7 @@ pub struct LoggingOpts {
     #[arg(long, default_value = "ghcid_ng=info")]
     pub tracing_filter: String,
 
-    /// How to display backtraces in error messages. '0' for no backtraces, '1' for standard
-    /// backtraces, and 'full' to display source snippets.
+    /// How to display backtraces in error messages.
     #[arg(long, env = "RUST_BACKTRACE", default_value = "0")]
     pub backtrace: RustBacktrace,
 }

--- a/src/ghci/stderr.rs
+++ b/src/ghci/stderr.rs
@@ -1,0 +1,88 @@
+use std::sync::Weak;
+
+use camino::Utf8PathBuf;
+use miette::IntoDiagnostic;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
+use tokio::io::BufWriter;
+use tokio::io::Lines;
+use tokio::process::ChildStderr;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tracing::instrument;
+
+use super::Ghci;
+
+/// An event sent to a `ghci` session's stderr channel.
+#[derive(Debug)]
+pub enum StderrEvent {
+    /// Write to the `error_path` (`ghcid.txt`) file, if any.
+    Write(oneshot::Sender<()>),
+}
+
+pub struct GhciStderr {
+    pub ghci: Weak<Mutex<Ghci>>,
+    pub reader: Lines<BufReader<ChildStderr>>,
+    pub receiver: mpsc::Receiver<StderrEvent>,
+    pub buffer: String,
+    pub error_path: Option<Utf8PathBuf>,
+}
+
+impl GhciStderr {
+    #[instrument(skip_all, name = "stderr", level = "debug")]
+    pub async fn run(mut self) -> miette::Result<()> {
+        loop {
+            // TODO: Could this cause problems where we get an event and a final stderr line is only
+            // processed after we write the error log?
+            tokio::select! {
+                Ok(Some(line)) = self.reader.next_line() => {
+                    self.ingest_line(line).await;
+                }
+                Some(event) = self.receiver.recv() => {
+                    match event {
+                        StderrEvent::Write(sender) => {
+                            let res = self.write().await;
+                            let _ = sender.send(());
+                            res?;
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn ingest_line(&mut self, line: String) {
+        self.buffer.push_str(&line);
+        self.buffer.push('\n');
+        eprintln!("{line}");
+    }
+
+    #[instrument(skip_all, level = "debug")]
+    async fn write(&mut self) -> miette::Result<()> {
+        if self.buffer.is_empty() {
+            // Nothing to do, don't wipe the error log file.
+            tracing::debug!("Buffer empty, not writing");
+            return Ok(());
+        }
+
+        if let Some(path) = &self.error_path {
+            tracing::debug!(?path, bytes = self.buffer.len(), "Writing error log");
+            let file = File::create(path).await.into_diagnostic()?;
+            let mut writer = BufWriter::new(file);
+            writer
+                .write_all(self.buffer.as_bytes())
+                .await
+                .into_diagnostic()?;
+            // This is load-bearing! If we don't properly flush/shutdown the handle, nothing gets
+            // written!
+            writer.shutdown().await.into_diagnostic()?;
+        }
+
+        self.buffer.clear();
+
+        Ok(())
+    }
+}

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -33,14 +33,6 @@ pub enum StdinEvent {
     ShowModules(oneshot::Sender<ModuleSet>),
 }
 
-impl StdinEvent {
-    /// Construct an initialize event and the corresponding receiver.
-    pub fn initialize() -> (Self, oneshot::Receiver<()>) {
-        let (sender, receiver) = oneshot::channel();
-        (Self::Initialize(sender), receiver)
-    }
-}
-
 pub struct GhciStdin {
     pub ghci: Weak<Mutex<Ghci>>,
     pub stdin: ChildStdin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> miette::Result<()> {
             .wrap_err("Failed to split `--command` value into arguments")?,
     ));
 
-    let ghci = Ghci::new(ghci_command).await?;
+    let ghci = Ghci::new(ghci_command, opts.errors.clone()).await?;
     let watcher = Watcher::new(
         ghci,
         &opts.watch.paths,

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -26,6 +26,12 @@ use crate::ghci::Ghci;
 /// A [`watchexec`] watcher which waits for file changes and sends reload events to the contained
 /// `ghci` session.
 pub struct Watcher {
+    /// The inner `Watchexec` struct.
+    ///
+    /// This field isn't read, but it has to be here or the watcher stops working. Dropping this
+    /// drops the watcher tasks too.
+    #[allow(dead_code)]
+    inner: Arc<Watchexec>,
     /// A handle to wait on the file watcher task.
     pub handle: JoinHandle<Result<(), watchexec::error::CriticalError>>,
 }
@@ -58,6 +64,7 @@ impl Watcher {
         let watcher_handle = watcher.main();
 
         Ok(Self {
+            inner: watcher,
             handle: watcher_handle,
         })
     }


### PR DESCRIPTION
This writes stderr to an output file, clearing it between reloads.