### PR TITLE
Log errors in async tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom",
+ "instant",
+ "rand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +546,7 @@ name = "ghcid-ng"
 version = "0.1.1"
 dependencies = [
  "aho-corasick",
+ "backoff",
  "camino",
  "clap",
  "expect-test",
@@ -894,6 +906,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1290,6 +1311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1371,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -1352,6 +1391,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 aho-corasick = "1.0.2"
+backoff = { version = "0.4.0", default-features = false }
 camino = "1.1.4"
 clap = { version = "4.3.2", features = ["derive", "wrap_help", "env"] }
 humantime = "2.1.0"


### PR DESCRIPTION
This will actually log errors using `tracing::error!`. No more silent errors!

The `backoff` crate does claim to support futures, but I couldn't get it to work with my functions. Something about calling an `&mut self` function, I think? Anyways, I can at least use their exponential backoff implementation, which is quite nice: it supports duration caps on both individual retry attempts and the total elapsed time, adjustable jitter, and fractional exponents.

I'm not in love with the boilerplate duplicated between the three main tasks, but it may have to do.

If I try to copy the [`backoff` async example](https://github.com/ihrwein/backoff/blob/master/examples/async.rs) like so:

```rust
backoff::future::retry(ExponentialBackoff::default(), || async move {
    match self.run_inner().await {
        Ok(()) => {
            // MPSC channel closed, probably a graceful shutdown?
            tracing::debug!("Channel closed");
            Ok(())
        }
        Err(err) => {
            tracing::error!("{err:?}");
            Err(backoff::Error::transient(err))
        }
    }
})
.await
```

I get this error:

```
error[E0507]: cannot move out of `self`, a captured variable in an `FnMut` closure
  --> src/ghci/stdin.rs:48:66
   |
47 |       pub async fn run(mut self) -> miette::Result<()> {
   |                        -------- captured outer variable
48 |           backoff::future::retry(ExponentialBackoff::default(), || async move {
   |  _______________________________________________________________--_^
   | |                                                               |
   | |                                                               captured by this `FnMut` closure
49 | |             match self.run_inner().await {
   | |                   ----
   | |                   |
   | |                   variable moved due to use in generator
   | |                   move occurs because `self` has type `GhciStdin`, which does not implement the `Copy` trait
50 | |                 Ok(()) => {
51 | |                     // MPSC channel closed, probably a graceful shutdown?
...  |
59 | |             }
60 | |         })
   | |_________^ `self` is moved here
```

If I use an `async` block instead of an `async move` block, I get this error:

```
error: captured variable cannot escape `FnMut` closure body
  --> src/ghci/stdin.rs:48:66
   |
47 |       pub async fn run(mut self) -> miette::Result<()> {
   |                        -------- variable defined here
48 |           backoff::future::retry(ExponentialBackoff::default(), || async {
   |  ________________________________________________________________-_^
   | |                                                                |
   | |                                                                inferred to be a `FnMut` closure
49 | |             match self.run_inner().await {
   | |                   ---- variable captured here
50 | |                 Ok(()) => {
51 | |                     // MPSC channel closed, probably a graceful shutdown?
...  |
59 | |             }
60 | |         })
   | |_________^ returns an `async` block that contains a reference to a captured variable, which then escapes the closure body
   |
   = note: `FnMut` closures only have access to their captured variables while they are executing...
   = note: ...therefore, they cannot allow references to captured variables to escape
```