### PR TITLE
Strip ANSI escapes when writing `ghcid.txt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "owo-colors",
  "pretty_assertions",
  "shell-words",
+ "strip-ansi-escapes",
  "tap",
  "textwrap 0.16.0",
  "time",
@@ -1554,6 +1555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad0ed65755f6fdd06f7afd1afefe7b2b220c2b197844687c2ea9d6d4807305e"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,6 +1895,26 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ nix = { version = "0.26.2", default_features = false, features = ["process"] }
 once_cell = "1.18.0"
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 shell-words = "1.1.0"
+strip-ansi-escapes = "0.1.2"
 tap = "1.0.1"
 textwrap = { version = "0.16.0", features = ["terminal_size"] }
 time = { version = "0.3.22", features = ["formatting"] }

--- a/src/ghci/stderr.rs
+++ b/src/ghci/stderr.rs
@@ -73,7 +73,7 @@ impl GhciStderr {
             let file = File::create(path).await.into_diagnostic()?;
             let mut writer = BufWriter::new(file);
             writer
-                .write_all(self.buffer.as_bytes())
+                .write_all(&strip_ansi_escapes::strip(self.buffer.as_bytes()))
                 .await
                 .into_diagnostic()?;
             // This is load-bearing! If we don't properly flush/shutdown the handle, nothing gets


### PR DESCRIPTION
This should make it easier to view `ghcid.txt` in a text editor.