### PR TITLE
Run tests on save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata 0.3.4",
+ "regex-automata 0.3.6",
  "serde",
 ]
 
@@ -558,6 +558,7 @@ dependencies = [
  "once_cell",
  "owo-colors",
  "pretty_assertions",
+ "regex",
  "shell-words",
  "strip-ansi-escapes",
  "tap",
@@ -1427,13 +1428,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.4",
+ "regex-automata 0.3.6",
  "regex-syntax 0.7.4",
 ]
 
@@ -1448,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ miette = { version = "5.9.0", features = ["fancy"] }
 nix = { version = "0.26.2", default_features = false, features = ["process"] }
 once_cell = "1.18.0"
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
+regex = { version = "1.9.3", default-features = false, features = ["perf", "std"] }
 shell-words = "1.1.0"
 strip-ansi-escapes = "0.1.2"
 tap = "1.0.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,11 +18,15 @@ pub struct Opts {
     #[arg(long)]
     pub command: Option<String>,
 
-    /// A shell command which runs tests. If given, this command will be run after reloads.
-    ///
-    /// May contain quoted arguments which will be parsed in a `sh`-like manner.
+    /// A `ghci` command which runs tests, like `TestMain.testMain`. If given, this command will be
+    /// run after reloads.
     #[arg(long)]
     pub test: Option<String>,
+
+    /// `ghci` commands to run on startup. Use `:set args ...` in combination with `--test` to set
+    /// the command-line arguments for tests.
+    #[arg(long)]
+    pub setup: Vec<String>,
 
     /// A file to write compilation errors to. This is analogous to `ghcid.txt`.
     #[arg(long)]

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -312,7 +312,7 @@ impl Ghci {
             );
             for path in add {
                 let add_result = this.lock().await.add_module(path).await?;
-                if let Some(Err(())) = add_result {
+                if let Some(CompilationResult::Err) = add_result {
                     compilation_failed = false;
                 }
             }
@@ -331,7 +331,7 @@ impl Ghci {
                 .await
                 .into_diagnostic()?;
             let reload_result = receiver.await.into_diagnostic()?;
-            if let Some(Err(())) = reload_result {
+            if let Some(CompilationResult::Err) = reload_result {
                 compilation_failed = false;
             }
         }
@@ -412,7 +412,7 @@ impl Ghci {
     pub async fn add_module(
         &mut self,
         path: Utf8PathBuf,
-    ) -> miette::Result<Option<Result<(), ()>>> {
+    ) -> miette::Result<Option<CompilationResult>> {
         let (sender, receiver) = oneshot::channel();
         self.stdin_channel
             .send(StdinEvent::AddModule(path.clone(), sender))
@@ -480,4 +480,13 @@ fn format_bulleted_list(items: &[impl Display]) -> String {
     } else {
         format!("• {}", items.iter().join("\n• "))
     }
+}
+
+/// The result of compiling modules in `ghci`.
+#[derive(Debug, Clone, Copy)]
+pub enum CompilationResult {
+    /// All the modules compiled successfully.
+    Ok,
+    /// Some modules failed to compile/load.
+    Err,
 }

--- a/src/ghci/stderr.rs
+++ b/src/ghci/stderr.rs
@@ -1,4 +1,4 @@
-use std::sync::Weak;
+use std::collections::BTreeMap;
 
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
@@ -12,24 +12,47 @@ use tokio::io::Lines;
 use tokio::process::ChildStderr;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio::sync::Mutex;
 use tracing::instrument;
 
-use super::Ghci;
+use super::Mode;
 
 /// An event sent to a `ghci` session's stderr channel.
 #[derive(Debug)]
 pub enum StderrEvent {
     /// Write to the `error_path` (`ghcid.txt`) file, if any.
     Write(oneshot::Sender<()>),
+
+    /// Set the compilation summary to the given string.
+    SetCompilationSummary {
+        summary: String,
+        sender: oneshot::Sender<()>,
+    },
+
+    /// Set the writer's mode.
+    Mode {
+        mode: Mode,
+        sender: oneshot::Sender<()>,
+    },
 }
 
 pub struct GhciStderr {
-    pub ghci: Weak<Mutex<Ghci>>,
     pub reader: Lines<BufReader<ChildStderr>>,
     pub receiver: mpsc::Receiver<StderrEvent>,
-    pub buffer: String,
+    /// A headline to write to the error log.
+    ///
+    /// This is a summary of the `ghci` session's status. Typically taken from compilation output,
+    /// of the form `(Ok|Failed), [0-9]+ modules loaded.`.
+    pub compilation_summary: String,
+    /// Output buffers, one per [`Mode`]. This lets us gather output for compilation and tests
+    /// separately. Useful to avoid clobbering the `error_path` with test data when there were
+    /// useful compilation errors stored.
+    pub buffers: BTreeMap<Mode, String>,
+    /// The path to write the error log to.
     pub error_path: Option<Utf8PathBuf>,
+    /// The mode we're currently reading output in.
+    pub mode: Mode,
+    /// `true` if we've read data from stderr but not yet written it to the error log.
+    pub has_unwritten_data: bool,
 }
 
 impl GhciStderr {
@@ -64,48 +87,108 @@ impl GhciStderr {
                     self.ingest_line(line).await;
                 }
                 Some(event) = self.receiver.recv() => {
-                    match event {
-                        StderrEvent::Write(sender) => {
-                            let res = self.write().await;
-                            let _ = sender.send(());
-                            res?;
-                        },
-                    }
+                    self.dispatch(event).await?;
                 }
             }
         }
     }
 
+    async fn dispatch(&mut self, event: StderrEvent) -> miette::Result<()> {
+        match event {
+            StderrEvent::Write(sender) => {
+                let res = self.write().await;
+                let _ = sender.send(());
+                res?;
+            }
+            StderrEvent::Mode { mode, sender } => {
+                self.set_mode(sender, mode).await;
+            }
+            StderrEvent::SetCompilationSummary { summary, sender } => {
+                self.set_compilation_summary(sender, summary).await;
+            }
+        }
+
+        Ok(())
+    }
+
     #[instrument(skip(self), level = "debug")]
     async fn ingest_line(&mut self, line: String) {
-        self.buffer.push_str(&line);
-        self.buffer.push('\n');
+        // We might not have a buffer for some modes, e.g. `Internal`.
+        if let Some(buffer) = self.buffers.get_mut(&self.mode) {
+            buffer.push_str(&line);
+            buffer.push('\n');
+            self.has_unwritten_data = true;
+        }
         eprintln!("{line}");
     }
 
     #[instrument(skip_all, level = "debug")]
     async fn write(&mut self) -> miette::Result<()> {
-        if self.buffer.is_empty() {
-            // Nothing to do, don't wipe the error log file.
-            tracing::debug!("Buffer empty, not writing");
+        if !self.has_unwritten_data {
+            tracing::debug!("No new data, not writing");
             return Ok(());
         }
 
         if let Some(path) = &self.error_path {
-            tracing::debug!(?path, bytes = self.buffer.len(), "Writing error log");
             let file = File::create(path).await.into_diagnostic()?;
             let mut writer = BufWriter::new(file);
-            writer
-                .write_all(&strip_ansi_escapes::strip(self.buffer.as_bytes()))
-                .await
-                .into_diagnostic()?;
+
+            if !self.compilation_summary.is_empty() {
+                tracing::debug!(?path, "Writing error log headline");
+                writer
+                    .write_all(self.compilation_summary.as_bytes())
+                    .await
+                    .into_diagnostic()?;
+            }
+
+            for (mode, buffer) in &self.buffers {
+                tracing::debug!(?path, %mode, bytes = buffer.len(), "Writing error log");
+                writer
+                    .write_all(&strip_ansi_escapes::strip(buffer.as_bytes()))
+                    .await
+                    .into_diagnostic()?;
+            }
+
             // This is load-bearing! If we don't properly flush/shutdown the handle, nothing gets
             // written!
             writer.shutdown().await.into_diagnostic()?;
         }
 
-        self.buffer.clear();
+        self.has_unwritten_data = false;
 
         Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn set_mode(&mut self, sender: oneshot::Sender<()>, mode: Mode) {
+        self.mode = mode;
+
+        // Clear the buffer for the newly-selected mode.
+        //
+        // TODO: What if this deletes useful errors that don't get resurfaced?
+        // For example, a user adds a new module and `ghci` shows errors with that module but not
+        // previous compilation errors in different modules.
+        // Maybe analagous to the way warnings can get hidden because they're only surfaced during
+        // compilation of that particular module and aren't fatal.
+        if let Some(buffer) = self.buffers.get_mut(&self.mode) {
+            buffer.clear();
+        }
+
+        // If we're compiling, also clear the headline so we don't write a stale status/module
+        // count.
+        if mode == Mode::Compiling {
+            self.compilation_summary.clear();
+        }
+
+        let _ = sender.send(());
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn set_compilation_summary(&mut self, sender: oneshot::Sender<()>, summary: String) {
+        if summary != self.compilation_summary {
+            self.compilation_summary = summary;
+            self.has_unwritten_data = true;
+        }
+        let _ = sender.send(());
     }
 }

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -1,4 +1,4 @@
-use std::sync::Weak;
+use std::time::Instant;
 
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
@@ -8,15 +8,16 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::ChildStdin;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio::sync::Mutex;
+use tokio::task::JoinSet;
 use tracing::instrument;
 
 use crate::haskell_show::HaskellShow;
 use crate::sync_sentinel::SyncSentinel;
 
 use super::show_modules::ModuleSet;
+use super::stderr::StderrEvent;
 use super::stdout::StdoutEvent;
-use super::Ghci;
+use super::Mode;
 use super::IO_MODULE_NAME;
 use super::PROMPT;
 
@@ -24,10 +25,18 @@ use super::PROMPT;
 #[derive(Debug)]
 pub enum StdinEvent {
     /// Initialize the `ghci` session; sets the initial imports, changes the prompt, etc.
-    Initialize(oneshot::Sender<()>),
+    Initialize {
+        sender: oneshot::Sender<()>,
+        setup_commands: Vec<String>,
+    },
     /// Reload the `ghci` session with `:reload`.
     Reload(oneshot::Sender<()>),
-    /// Add a module to the `ghci` session by path with `:load`.
+    /// Run the user-provided test command, if any.
+    Test {
+        sender: oneshot::Sender<()>,
+        test_command: Option<String>,
+    },
+    /// Add a module to the `ghci` session by path with `:add`.
     AddModule(Utf8PathBuf, oneshot::Sender<()>),
     /// Sync the `ghci` session's input/output.
     Sync(SyncSentinel),
@@ -36,9 +45,13 @@ pub enum StdinEvent {
 }
 
 pub struct GhciStdin {
-    pub ghci: Weak<Mutex<Ghci>>,
+    /// Inner stdin writer.
     pub stdin: ChildStdin,
+    /// Channel sender for communicating with the stdout task.
     pub stdout_sender: mpsc::Sender<StdoutEvent>,
+    /// Channel sender for communicating with the stderr task.
+    pub stderr_sender: mpsc::Sender<StderrEvent>,
+    /// Channel receiver for communicating with this task.
     pub receiver: mpsc::Receiver<StdinEvent>,
 }
 
@@ -68,11 +81,20 @@ impl GhciStdin {
     pub async fn run_inner(&mut self) -> miette::Result<()> {
         while let Some(event) = self.receiver.recv().await {
             match event {
-                StdinEvent::Initialize(sender) => {
-                    self.initialize(sender).await?;
+                StdinEvent::Initialize {
+                    sender,
+                    setup_commands,
+                } => {
+                    self.initialize(sender, setup_commands).await?;
                 }
                 StdinEvent::Reload(sender) => {
                     self.reload(sender).await?;
+                }
+                StdinEvent::Test {
+                    sender,
+                    test_command,
+                } => {
+                    self.test(sender, test_command).await?;
                 }
                 StdinEvent::AddModule(path, sender) => {
                     self.add_module(path, sender).await?;
@@ -122,24 +144,51 @@ impl GhciStdin {
     }
 
     #[instrument(skip_all, level = "debug")]
-    async fn initialize(&mut self, sender: oneshot::Sender<()>) -> miette::Result<()> {
-        // For Stack, send a blank line to skip an initial prompt.
-        //
-        // See: https://github.com/ndmitchell/ghcid/issues/57
-        self.stdin.write_all(b"\n").await.into_diagnostic()?;
-
+    async fn initialize(
+        &mut self,
+        sender: oneshot::Sender<()>,
+        setup_commands: Vec<String>,
+    ) -> miette::Result<()> {
+        self.set_mode(Mode::Internal).await?;
         self.write_line(&format!(":set prompt {PROMPT}\n")).await?;
         self.write_line(&format!(":set prompt-cont {PROMPT}\n"))
             .await?;
         self.write_line(&format!("import qualified System.IO as {IO_MODULE_NAME}\n"))
             .await?;
+
+        for command in setup_commands {
+            tracing::debug!(?command, "Running user intialization command");
+            self.write_line(&format!("{command}\n")).await?;
+        }
+
         let _ = sender.send(());
         Ok(())
     }
 
     #[instrument(skip_all, level = "debug")]
     async fn reload(&mut self, sender: oneshot::Sender<()>) -> miette::Result<()> {
+        self.set_mode(Mode::Compiling).await?;
         self.write_line_sender(":reload\n", sender).await?;
+        Ok(())
+    }
+
+    #[instrument(skip_all, level = "debug")]
+    async fn test(
+        &mut self,
+        sender: oneshot::Sender<()>,
+        test_command: Option<String>,
+    ) -> miette::Result<()> {
+        if let Some(test_command) = test_command {
+            self.set_mode(Mode::Testing).await?;
+            tracing::debug!(command = ?test_command, "Running user test command");
+            tracing::info!("Running tests");
+            let start_time = Instant::now();
+            self.write_line(&format!("{test_command}\n")).await?;
+            tracing::info!("Finished running tests in {:.2?}", start_time.elapsed());
+        }
+
+        let _ = sender.send(());
+
         Ok(())
     }
 
@@ -149,14 +198,24 @@ impl GhciStdin {
         path: Utf8PathBuf,
         sender: oneshot::Sender<()>,
     ) -> miette::Result<()> {
-        // We use `:load` here instead of `:add` because `:add` forces interpreted mode.
-        self.write_line_sender(&format!(":load {path}\n"), sender)
+        self.set_mode(Mode::Compiling).await?;
+
+        // We use `:add` because `:load` unloads all previously loaded modules:
+        //
+        // > All previously loaded modules, except package modules, are forgotten. The new set of
+        // > modules is known as the target set. Note that :load can be used without any arguments
+        // > to unload all the currently loaded modules and bindings.
+        //
+        // https://downloads.haskell.org/ghc/latest/docs/users_guide/ghci.html#ghci-cmd-:load
+        self.write_line_sender(&format!(":add {path}\n"), sender)
             .await?;
         Ok(())
     }
 
     #[instrument(skip(self), level = "debug")]
     async fn sync(&mut self, sentinel: SyncSentinel) -> miette::Result<()> {
+        self.set_mode(Mode::Internal).await?;
+
         self.stdin
             .write_all(
                 format!("{IO_MODULE_NAME}.putStrLn {}\n", sentinel.haskell_show()).as_bytes(),
@@ -174,6 +233,8 @@ impl GhciStdin {
 
     #[instrument(skip(self), level = "debug")]
     async fn show_modules(&mut self, sender: oneshot::Sender<ModuleSet>) -> miette::Result<()> {
+        self.set_mode(Mode::Internal).await?;
+
         self.stdin
             .write_all(b":show modules\n")
             .await
@@ -183,6 +244,36 @@ impl GhciStdin {
             .send(StdoutEvent::ShowModules(sender))
             .await
             .into_diagnostic()?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn set_mode(&self, mode: Mode) -> miette::Result<()> {
+        let mut set = JoinSet::<Result<(), oneshot::error::RecvError>>::new();
+
+        {
+            let (sender, receiver) = oneshot::channel();
+            self.stdout_sender
+                .send(StdoutEvent::Mode { mode, sender })
+                .await
+                .into_diagnostic()?;
+            set.spawn(receiver);
+        }
+
+        {
+            let (sender, receiver) = oneshot::channel();
+            self.stderr_sender
+                .send(StderrEvent::Mode { mode, sender })
+                .await
+                .into_diagnostic()?;
+            set.spawn(receiver);
+        }
+
+        // Wait until the other tasks have finished setting the new mode.
+        while let Some(result) = set.join_next().await {
+            result.into_diagnostic()?.into_diagnostic()?;
+        }
+
         Ok(())
     }
 }

--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -1,24 +1,28 @@
-use std::sync::Weak;
+use std::sync::OnceLock;
 
 use aho_corasick::AhoCorasick;
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
+use miette::Context;
+use miette::IntoDiagnostic;
+use regex::Regex;
 use tokio::io::Stdout;
 use tokio::process::ChildStdout;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio::sync::Mutex;
 use tracing::instrument;
 
 use crate::aho_corasick::AhoCorasickExt;
 use crate::incremental_reader::IncrementalReader;
 use crate::incremental_reader::WriteBehavior;
+use crate::lines::Lines;
 use crate::sync_sentinel::SyncSentinel;
 
 use super::show_modules::ModuleSet;
 use super::stderr::StderrEvent;
-use super::stdin::StdinEvent;
-use super::Ghci;
+use super::Mode;
+
+static COMPILATION_FINISHED_RE: OnceLock<Regex> = OnceLock::new();
 
 /// An event sent to a `ghci` session's stdout channel.
 #[derive(Debug)]
@@ -31,16 +35,27 @@ pub enum StdoutEvent {
     Sync(SyncSentinel),
     /// Parse `:show modules` output.
     ShowModules(oneshot::Sender<ModuleSet>),
+    /// Set the session's mode.
+    Mode {
+        mode: Mode,
+        sender: oneshot::Sender<()>,
+    },
 }
 
 pub struct GhciStdout {
-    pub ghci: Weak<Mutex<Ghci>>,
+    /// Reader for parsing and forwarding the underlying stdout stream.
     pub reader: IncrementalReader<ChildStdout, Stdout>,
-    pub stdin_sender: mpsc::Sender<StdinEvent>,
+    /// Channel for communicating with the stderr task.
     pub stderr_sender: mpsc::Sender<StderrEvent>,
+    /// Channel for communicating with this task.
     pub receiver: mpsc::Receiver<StdoutEvent>,
+    /// Prompt patterns to match. Constructing these `AhoCorasick` automatons is costly so we store
+    /// them in the task state.
     pub prompt_patterns: AhoCorasick,
+    /// A buffer to read data into. Lets us avoid allocating buffers in the [`IncrementalReader`].
     pub buffer: Vec<u8>,
+    /// The mode we're currently reading output in.
+    pub mode: Mode,
 }
 
 impl GhciStdout {
@@ -81,6 +96,9 @@ impl GhciStdout {
                 StdoutEvent::ShowModules(sender) => {
                     self.show_modules(sender).await?;
                 }
+                StdoutEvent::Mode { mode, sender } => {
+                    self.set_mode(sender, mode).await;
+                }
             }
         }
 
@@ -99,23 +117,16 @@ impl GhciStdout {
             .reader
             .read_until(&bootup_patterns, WriteBehavior::Write, &mut self.buffer)
             .await?;
-        tracing::debug!(?lines, "ghci started");
+        tracing::debug!(?lines, "ghci started, saw version marker");
 
-        let init_prompt_patterns = AhoCorasick::from_anchored_patterns(["ghci> "]);
         // We know that we'll get _one_ `ghci> ` prompt on startup.
-        self.prompt(when_ready, Some(&init_prompt_patterns)).await?;
-        // But we might get more than one `ghci> ` prompt, so digest any others from the buffer.
-        while let Some(lines) = self
-            .reader
-            .try_read_until(
-                &init_prompt_patterns,
-                WriteBehavior::NoFinalLine,
-                &mut self.buffer,
-            )
-            .await?
-        {
-            tracing::debug!(?lines, "initial ghci prompt");
-        }
+        let init_prompt_patterns = AhoCorasick::from_anchored_patterns(["ghci> "]);
+        let (sender, receiver) = oneshot::channel();
+        self.prompt(sender, Some(&init_prompt_patterns)).await?;
+        receiver.await.into_diagnostic()?;
+        tracing::debug!("Saw initial `ghci> ` prompt");
+
+        let _ = when_ready.send(());
 
         Ok(())
     }
@@ -140,7 +151,14 @@ impl GhciStdout {
                 &mut self.buffer,
             )
             .await?;
-        tracing::debug!(?lines, "Got data from ghci");
+        tracing::debug!(lines = lines.len(), "Got data from ghci");
+
+        if self.mode == Mode::Compiling {
+            self.get_status_from_compile_output(lines)
+                .await
+                .wrap_err("Failed to get status from compilation output")?;
+        }
+
         // Tell the stderr stream to write the error log and then finish.
         let _ = self.stderr_sender.send(StderrEvent::Write(sender)).await;
         Ok(())
@@ -181,6 +199,35 @@ impl GhciStdout {
             .await?;
         let map = ModuleSet::from_lines(&lines)?;
         let _ = sender.send(map);
+        Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn set_mode(&mut self, sender: oneshot::Sender<()>, mode: Mode) {
+        self.mode = mode;
+        let _ = sender.send(());
+    }
+
+    async fn get_status_from_compile_output(&mut self, mut lines: Lines) -> miette::Result<()> {
+        // TODO: This would be pretty clumsy if we wanted to use this regex in multiple places.
+        // Might be worth bringing in `lazy_static`.
+        let compilation_finished_re = COMPILATION_FINISHED_RE
+            .get_or_init(|| Regex::new(r"^(?:Ok|Failed), [0-9]+ modules loaded.$").unwrap());
+
+        if let Some(line) = lines.pop() {
+            if compilation_finished_re.is_match(&line) {
+                let (sender, receiver) = oneshot::channel();
+                self.stderr_sender
+                    .send(StderrEvent::SetCompilationSummary {
+                        summary: line,
+                        sender,
+                    })
+                    .await
+                    .into_diagnostic()?;
+                receiver.await.into_diagnostic()?;
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> miette::Result<()> {
             .wrap_err("Failed to split `--command` value into arguments")?,
     ));
 
-    let ghci = Ghci::new(ghci_command, opts.errors.clone())
+    let ghci = Ghci::new(ghci_command, opts.errors.clone(), opts.setup, opts.test)
         .await
         .wrap_err("Failed to start `ghci`")?;
     let watcher = Watcher::new(


### PR DESCRIPTION


This adds `--test` and `--setup` arguments which can be used to run a test suite on reload.
