### PR TITLE
Release version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "ghcid-ng"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghcid-ng"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = [
     "Rebecca Turner <rebeccat@mercury.com>"

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         final: prev: {
           ghcid-ng = final.rustPlatform.buildRustPackage {
             pname = "ghcid-ng";
-            version = "0.1.1"; # LOAD-BEARING COMMENT. See: `.github/workflows/version.yaml`
+            version = "0.2.0"; # LOAD-BEARING COMMENT. See: `.github/workflows/version.yaml`
 
             cargoLock = {
               lockFile = ./Cargo.lock;


### PR DESCRIPTION
Update version to 0.2.0 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.