### PR TITLE
Don't run tests when compilation fails

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -303,7 +303,7 @@ impl Ghci {
         }
 
         let needs_add_or_reload = !add.is_empty() || !needs_reload.is_empty();
-        let mut compilation_failed = needs_add_or_reload;
+        let mut compilation_failed = false;
 
         if !add.is_empty() {
             tracing::info!(
@@ -313,7 +313,7 @@ impl Ghci {
             for path in add {
                 let add_result = this.lock().await.add_module(path).await?;
                 if let Some(CompilationResult::Err) = add_result {
-                    compilation_failed = false;
+                    compilation_failed = true;
                 }
             }
         }
@@ -332,7 +332,7 @@ impl Ghci {
                 .into_diagnostic()?;
             let reload_result = receiver.await.into_diagnostic()?;
             if let Some(CompilationResult::Err) = reload_result {
-                compilation_failed = false;
+                compilation_failed = true;
             }
         }
 

--- a/src/ghci/stderr.rs
+++ b/src/ghci/stderr.rs
@@ -159,7 +159,7 @@ impl GhciStderr {
         Ok(())
     }
 
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self, sender), level = "debug")]
     async fn set_mode(&mut self, sender: oneshot::Sender<()>, mode: Mode) {
         self.mode = mode;
 
@@ -183,7 +183,7 @@ impl GhciStderr {
         let _ = sender.send(());
     }
 
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self, sender), level = "debug")]
     async fn set_compilation_summary(&mut self, sender: oneshot::Sender<()>, summary: String) {
         if summary != self.compilation_summary {
             self.compilation_summary = summary;

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -127,7 +127,7 @@ impl GhciStdin {
     /// stdout.
     ///
     /// The `line` should contain the trailing newline.
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self, sender), level = "debug")]
     async fn write_line_sender(
         &mut self,
         line: &str,
@@ -144,7 +144,7 @@ impl GhciStdin {
         Ok(())
     }
 
-    #[instrument(skip_all, level = "debug")]
+    #[instrument(skip(self, sender), level = "debug")]
     async fn initialize(
         &mut self,
         sender: oneshot::Sender<()>,
@@ -196,7 +196,7 @@ impl GhciStdin {
         Ok(())
     }
 
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self, sender), level = "debug")]
     async fn add_module(
         &mut self,
         path: Utf8PathBuf,
@@ -235,7 +235,7 @@ impl GhciStdin {
         Ok(())
     }
 
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self, sender), level = "debug")]
     async fn show_modules(&mut self, sender: oneshot::Sender<ModuleSet>) -> miette::Result<()> {
         self.set_mode(Mode::Internal).await?;
 

--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -213,7 +213,7 @@ impl GhciStdout {
         Ok(())
     }
 
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self, sender), level = "debug")]
     async fn set_mode(&mut self, sender: oneshot::Sender<()>, mode: Mode) {
         self.mode = mode;
         let _ = sender.send(());
@@ -231,8 +231,10 @@ impl GhciStdout {
         if let Some(line) = lines.pop() {
             if compilation_finished_re().is_match(&line) {
                 let result = if line.starts_with("Ok") {
+                    tracing::debug!("Compilation succeeded");
                     CompilationResult::Ok
                 } else {
+                    tracing::debug!("Compilation failed");
                     CompilationResult::Err
                 };
 
@@ -247,6 +249,8 @@ impl GhciStdout {
                 receiver.await.into_diagnostic()?;
 
                 return Ok(Some(result));
+            } else {
+                tracing::debug!("Didn't parse 'modules loaded' line");
             }
         }
 


### PR DESCRIPTION
This was the intended behavior in #11, but I got the booleans backwards. Don't worry, tests are next on the roadmap...