### PR TITLE
Fix "module defined in multiple files"

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -270,7 +270,7 @@ impl Ghci {
                         break;
                     }
                     FileEvent::Modify(path) => {
-                        if guard.modules.contains_source_path(&path) {
+                        if guard.modules.contains_source_path(&path)? {
                             // We can `:reload` paths `ghci` already has loaded.
                             tracing::debug!(?path, "Needs reload");
                             needs_reload.push(path);
@@ -418,8 +418,7 @@ impl Ghci {
             .send(StdinEvent::AddModule(path.clone(), sender))
             .await
             .into_diagnostic()?;
-        // TODO: What if adding the new module fails?
-        self.modules.insert_source_path(path);
+        self.modules.insert_source_path(path)?;
         receiver.await.into_diagnostic()
     }
 


### PR DESCRIPTION
We hadn't been canonicalizing paths before checking if they were in the `ModuleSet` of loaded modules previously. This led to modules being `:add`ed when a simple `:reload` would've sufficed, leading to this error:

```
<no location info>: error: [GHC-29235]
    module 'mwb-0-inplace-test-dev:Foo' is defined in multiple files: Foo.hs
                                                                      Foo.hs
```