### PR TITLE
Allow customizing logged span events

### DIFF
--- a/src/clap/fmt_span.rs
+++ b/src/clap/fmt_span.rs
@@ -1,0 +1,62 @@
+//! Adapter for pasing the [`FmtSpan`] type.
+
+use clap::builder::EnumValueParser;
+use clap::builder::PossibleValue;
+use clap::builder::TypedValueParser;
+use clap::builder::ValueParserFactory;
+use tracing_subscriber::fmt::format::FmtSpan;
+
+/// Wrapper around [`FmtSpan`].
+#[derive(Clone)]
+pub struct FmtSpanWrapper(FmtSpan);
+
+impl From<FmtSpanWrapper> for FmtSpan {
+    fn from(value: FmtSpanWrapper) -> Self {
+        value.0
+    }
+}
+
+impl clap::ValueEnum for FmtSpanWrapper {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            Self(FmtSpan::NEW),
+            Self(FmtSpan::ENTER),
+            Self(FmtSpan::EXIT),
+            Self(FmtSpan::CLOSE),
+            Self(FmtSpan::NONE),
+            Self(FmtSpan::ACTIVE),
+            Self(FmtSpan::FULL),
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self.0 {
+            FmtSpan::NEW => PossibleValue::new("new").help("Log when spans are created"),
+            FmtSpan::ENTER => PossibleValue::new("enter").help("Log when spans are entered"),
+            FmtSpan::EXIT => PossibleValue::new("exit").help("Log when spans are exited"),
+            FmtSpan::CLOSE => PossibleValue::new("close").help("Log when spans are dropped"),
+            FmtSpan::NONE => PossibleValue::new("none").help("Do not log span events"),
+            FmtSpan::ACTIVE => {
+                PossibleValue::new("active").help("Log when spans are entered/exited")
+            }
+            FmtSpan::FULL => PossibleValue::new("full").help("Log all span events"),
+            _ => {
+                return None;
+            }
+        })
+    }
+}
+
+/// [`clap`] parser factory for [`FmtSpan`] values.
+pub struct FmtSpanParserFactory;
+
+impl ValueParserFactory for FmtSpanParserFactory {
+    type Parser = clap::builder::MapValueParser<
+        EnumValueParser<FmtSpanWrapper>,
+        fn(FmtSpanWrapper) -> FmtSpan,
+    >;
+
+    fn value_parser() -> Self::Parser {
+        EnumValueParser::<FmtSpanWrapper>::new().map(Into::into)
+    }
+}

--- a/src/clap/mod.rs
+++ b/src/clap/mod.rs
@@ -2,9 +2,11 @@
 
 mod camino;
 mod error_message;
+mod fmt_span;
 mod humantime;
 mod rust_backtrace;
 
 pub use self::humantime::DurationValueParser;
 pub use error_message::value_validation_error;
+pub use fmt_span::FmtSpanParserFactory;
 pub use rust_backtrace::RustBacktrace;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,18 +107,6 @@ pub struct LoggingOpts {
     pub trace_spans: Vec<FmtSpan>,
 }
 
-/// Options to run in server mode.
-#[derive(Debug, Clone, clap::Args)]
-#[clap(next_help_heading = "Server options")]
-pub struct ServerOpts {
-    /// Start in server mode, binding to the given socket path.
-    ///
-    /// The socket can be used to send commands to `ghcid-ng` and to receive event notifications
-    /// back in turn. The communication protocol is unstable for now.
-    #[arg(long, value_name = "PATH")]
-    pub socket: Option<Utf8PathBuf>,
-}
-
 impl Opts {
     /// Perform late initialization of the command-line arguments. If `init` isn't called before
     /// the arguments are used, the behavior is undefined.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,8 +3,11 @@
 use std::time::Duration;
 
 use camino::Utf8PathBuf;
+use clap::builder::ValueParserFactory;
 use clap::Parser;
+use tracing_subscriber::fmt::format::FmtSpan;
 
+use crate::clap::FmtSpanParserFactory;
 use crate::clap::RustBacktrace;
 
 /// A `ghci`-based file watcher and Haskell recompiler.
@@ -91,6 +94,27 @@ pub struct LoggingOpts {
     /// How to display backtraces in error messages.
     #[arg(long, env = "RUST_BACKTRACE", default_value = "0")]
     pub backtrace: RustBacktrace,
+
+    /// When to log span events, which loosely correspond to tasks being run in the async runtime.
+    #[arg(
+        long,
+        default_value = "new,close",
+        value_delimiter = ',',
+        value_parser = FmtSpanParserFactory::value_parser()
+    )]
+    pub trace_spans: Vec<FmtSpan>,
+}
+
+/// Options to run in server mode.
+#[derive(Debug, Clone, clap::Args)]
+#[clap(next_help_heading = "Server options")]
+pub struct ServerOpts {
+    /// Start in server mode, binding to the given socket path.
+    ///
+    /// The socket can be used to send commands to `ghcid-ng` and to receive event notifications
+    /// back in turn. The communication protocol is unstable for now.
+    #[arg(long, value_name = "PATH")]
+    pub socket: Option<Utf8PathBuf>,
 }
 
 impl Opts {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,8 @@ pub struct LoggingOpts {
     pub backtrace: RustBacktrace,
 
     /// When to log span events, which loosely correspond to tasks being run in the async runtime.
+    ///
+    /// Allows multiple values, comma-separated.
     #[arg(
         long,
         default_value = "new,close",

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use tokio::sync::Mutex;
 async fn main() -> miette::Result<()> {
     miette::set_panic_hook();
     let opts = cli::Opts::parse().tap_mut(|opts| opts.init());
-    tracing::install_tracing(&opts.logging.tracing_filter)?;
+    tracing::install_tracing(&opts.logging.tracing_filter, &opts.logging.trace_spans)?;
 
     ::tracing::warn!(
         "This is a prerelease alpha version of `ghcid-ng`! Expect a rough user experience, and please report bugs or other issues to the #mighty-dux channel on Slack."


### PR DESCRIPTION
Currently, new/close span events are logged (that is, when a span is created for the first time, usually when an `#[instrument]`ed function is called, and when spans are closed, usually when those functions return). It can be useful to disable those for terser logs, or to enable more events for greater detail.

This change adds a `--trace-spans` argument to customize which span events are logged.

Before shipping 1.0, we should clean up the option names. Maybe `--tracing-filter` could be `--log` or something.
