### PR TITLE
Use crane for Nix builds

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -105,16 +105,6 @@ jobs:
         run: |
           echo "version=$(./.github/workflows/get-crate-version.sh)" >> "$GITHUB_OUTPUT"
 
-      - name: Increment `flake.nix` version
-        run: |
-          sed -i \
-              -e "s/version = \"[^\"]*\"; # LOAD-BEARING COMMENT/version = \"${{ steps.new_cargo_metadata.outputs.version }}\"; # LOAD-BEARING COMMENT/" \
-              flake.nix
-
-          # Commit the new changes
-          git add flake.nix
-          git commit --amend --no-edit
-
       - name: Create release PR
         id: release_pr
         uses: peter-evans/create-pull-request@v5

--- a/flake.lock
+++ b/flake.lock
@@ -18,8 +18,12 @@
     },
     "crane": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -55,43 +59,9 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1692799911,
@@ -126,8 +96,8 @@
       "inputs": {
         "advisory-db": "advisory-db",
         "crane": "crane",
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     },
@@ -157,21 +127,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,61 @@
 {
   "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1692985935,
+        "narHash": "sha256-hD7PPA9yBJntT5l4H+DGakOGzHaHLyxQhPztoFWbO1E=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "d401af5af8e74d61872688d6228d067c553db2c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1692750383,
+        "narHash": "sha256-n5P5HOXuu23UB1h9PuayldnRRVQuXJLpoO+xqtMO3ws=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "ef5d11e3c2e5b3924eb0309dba2e1fea2d9062ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1673956053,
@@ -34,13 +89,31 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691165048,
-        "narHash": "sha256-q3Fy/DG0iAlBI94JONEEQH/AyjlIMwjBLIMihZHtIWM=",
+        "lastModified": 1693090222,
+        "narHash": "sha256-yRPSjFfPOa+PWcbwid1RbzYQ6ZO1i9+bnZI9Ppatas4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3f9ce2a8e2520f4f02406b5e0ea170755d27359",
+        "rev": "a7d27e87ee8a2b5b5a6bd39e5c3cdf7549606923",
         "type": "github"
       },
       "original": {
@@ -51,12 +124,54 @@
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
       }
     },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1691374719,
+        "narHash": "sha256-HCodqnx1Mi2vN4f3hjRPc7+lSQy18vRn8xWW68GeQOg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b520a3889b24aaf909e287d19d406862ced9ffc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -72,8 +72,6 @@
           });
       in {
         checks = {
-          inherit ghcid-ng;
-
           ghcid-ng-tests = craneLib.cargoTest commonArgs;
           ghcid-ng-clippy = craneLib.cargoClippy (commonArgs
             // {

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
     crane = {
       url = "github:ipetkov/crane";
+      inputs.flake-compat.follows = "flake-compat";
+      inputs.flake-utils.follows = "flake-utils";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     advisory-db = {

--- a/flake.nix
+++ b/flake.nix
@@ -42,15 +42,11 @@
           // {
             inherit src;
 
-            buildInputs =
-              [
-                pkgs.nix
-              ]
-              ++ lib.optionals pkgs.stdenv.isDarwin [
-                # Additional darwin specific inputs can be set here
-                pkgs.libiconv
-                pkgs.darwin.apple_sdk.frameworks.CoreServices
-              ];
+            buildInputs = lib.optionals pkgs.stdenv.isDarwin [
+              # Additional darwin specific inputs can be set here
+              pkgs.libiconv
+              pkgs.darwin.apple_sdk.frameworks.CoreServices
+            ];
           };
 
         # Build *just* the cargo dependencies, so we can reuse

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,14 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
       url = "github:edolstra/flake-compat";
@@ -13,68 +21,88 @@
   outputs = {
     self,
     nixpkgs,
+    crane,
     flake-utils,
+    advisory-db,
     flake-compat,
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [self.overlays.default];
         };
-      in {
-        packages = rec {
-          ghcid-ng = pkgs.ghcid-ng;
-          default = ghcid-ng;
-        };
-        checks = self.packages.${system};
+        inherit (pkgs) lib;
 
-        # for debugging
-        # inherit pkgs;
+        craneLib = crane.lib.${system};
 
-        devShells.default = pkgs.ghcid-ng.overrideAttrs (
-          old: {
-            # Make rust-analyzer work
-            RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+        src = craneLib.cleanCargoSource ./.;
 
-            # Any dev tools you use in excess of the rust ones
-            nativeBuildInputs =
-              old.nativeBuildInputs;
-          }
-        );
-      }
-    )
-    // {
-      overlays.default = (
-        final: prev: {
-          ghcid-ng = final.rustPlatform.buildRustPackage {
-            pname = "ghcid-ng";
-            version = "0.3.0"; # LOAD-BEARING COMMENT. See: `.github/workflows/version.yaml`
+        commonArgs' =
+          (craneLib.crateNameFromCargoToml {cargoToml = ./Cargo.toml;})
+          // {
+            inherit src;
 
-            cargoLock = {
-              lockFile = ./Cargo.lock;
-            };
-
-            src = ./.;
-
-            # Tools on the builder machine needed to build; e.g. pkg-config
-            nativeBuildInputs = [
-              final.rustfmt
-              final.clippy
-            ];
-
-            # Native libs
             buildInputs =
-              final.lib.optionals
-              final.stdenv.isDarwin
-              [final.darwin.apple_sdk.frameworks.CoreServices];
-
-            postCheck = ''
-              cargo fmt --check && echo "\`cargo fmt\` is OK"
-              cargo clippy -- --deny warnings && echo "\`cargo clippy\` is OK"
-            '';
+              [
+                pkgs.nix
+              ]
+              ++ lib.optionals pkgs.stdenv.isDarwin [
+                # Additional darwin specific inputs can be set here
+                pkgs.libiconv
+                pkgs.darwin.apple_sdk.frameworks.CoreServices
+              ];
           };
-        }
-      );
-    };
+
+        # Build *just* the cargo dependencies, so we can reuse
+        # all of that work (e.g. via cachix) when running in CI
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs';
+
+        commonArgs =
+          commonArgs'
+          // {
+            inherit cargoArtifacts;
+          };
+
+        # Build the actual crate itself, reusing the dependency
+        # artifacts from above.
+        ghcid-ng = craneLib.buildPackage (commonArgs
+          // {
+            # Don't run tests; we'll do that in a separate derivation.
+            # This will allow people to install and depend on `ghcid-ng`
+            # without downloading a half dozen different versions of GHC.
+            doCheck = false;
+          });
+      in {
+        checks = {
+          inherit ghcid-ng;
+
+          ghcid-ng-tests = craneLib.cargoTest commonArgs;
+          ghcid-ng-clippy = craneLib.cargoClippy (commonArgs
+            // {
+              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+            });
+          ghcid-ng-doc = craneLib.cargoDoc commonArgs;
+          ghcid-ng-fmt = craneLib.cargoFmt commonArgs;
+          ghcid-ng-audit = craneLib.cargoAudit (commonArgs
+            // {
+              inherit advisory-db;
+            });
+        };
+
+        packages.default = ghcid-ng;
+        apps.default = flake-utils.lib.mkApp {drv = ghcid-ng;};
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = builtins.attrValues self.checks.${system};
+
+          # Make rust-analyzer work
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+
+          # Any dev tools you use in excess of the rust ones
+          nativeBuildInputs = [
+            pkgs.rust-analyzer
+          ];
+        };
+      }
+    );
 }

--- a/src/fake_reader.rs
+++ b/src/fake_reader.rs
@@ -18,13 +18,6 @@ pub struct FakeReader {
 }
 
 impl FakeReader {
-    /// Construct a `FakeReader` from an iterator of bytes.
-    pub fn with_chunks(chunks: impl IntoIterator<Item = impl Into<Vec<u8>>>) -> Self {
-        Self {
-            chunks: chunks.into_iter().map(|chunk| chunk.into()).collect(),
-        }
-    }
-
     /// Construct a `FakeReader` from an iterator of strings.
     pub fn with_str_chunks(chunks: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
         Self {
@@ -33,18 +26,6 @@ impl FakeReader {
                 .map(|chunk| chunk.as_ref().bytes().collect())
                 .collect(),
         }
-    }
-
-    /// Add a string chunk to the end of this reader.
-    pub fn push_str_chunk(&mut self, chunk: impl AsRef<str>) -> &mut Self {
-        self.chunks.push_back(chunk.as_ref().bytes().collect());
-        self
-    }
-
-    /// Add a bytes chunk to the end of this reader.
-    pub fn push_chunk(&mut self, chunk: impl Into<Vec<u8>>) -> &mut Self {
-        self.chunks.push_back(chunk.into());
-        self
     }
 }
 

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -126,12 +126,11 @@ impl Ghci {
         let stdout_handle = task::spawn(async { Ok(()) });
         let stderr_handle = task::spawn(async { Ok(()) });
 
-        let stdin =
-              GhciStdin {
-                stdin,
-                stdout_sender: stdout_sender.clone(),
-                stderr_sender: stderr_sender.clone(),
-              };
+        let stdin = GhciStdin {
+            stdin,
+            stdout_sender: stdout_sender.clone(),
+            stderr_sender: stderr_sender.clone(),
+        };
 
         let mut ret = Ghci {
             command: command_arc,


### PR DESCRIPTION
[Crane](https://crane.dev/) is a Nix framework for building Rust packages. The main benefit is that it separates the build of the dependency packages into a separate derivation, so that those artifacts can be reused between builds and CI runs.