### PR TITLE
Add test Haskell project

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,15 @@
 
         craneLib = crane.lib.${system};
 
-        src = craneLib.cleanCargoSource ./.;
+        src = lib.cleanSourceWith {
+          src = craneLib.path ./.;
+          filter = let
+            # Keep test project data, needed for the build.
+            testDataFilter = path: _type: lib.hasInfix "tests/data" path;
+          in
+            path: type:
+              (testDataFilter path type) || (craneLib.filterCargoSources path type);
+        };
 
         commonArgs' =
           (craneLib.crateNameFromCargoToml {cargoToml = ./ghcid-ng/Cargo.toml;})

--- a/ghcid-ng/tests/data/simple/simple.cabal
+++ b/ghcid-ng/tests/data/simple/simple.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name: my-simple-package
+version: 0.1.0.0
+license: MIT
+author: Rebecca Turner
+maintainer: rebeccat@mercury.com
+build-type: Simple
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import: warnings
+    default-language: Haskell2010
+    hs-source-dirs: src
+    build-depends: base
+    exposed-modules:
+        MyLib,
+        MyModule
+
+test-suite my-simple-package-test
+    import: warnings
+    default-language: Haskell2010
+    type: exitcode-stdio-1.0
+    hs-source-dirs: test
+    main-is: Main.hs
+    build-depends:
+        base,
+        my-simple-package

--- a/ghcid-ng/tests/data/simple/src/MyLib.hs
+++ b/ghcid-ng/tests/data/simple/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/ghcid-ng/tests/data/simple/src/MyModule.hs
+++ b/ghcid-ng/tests/data/simple/src/MyModule.hs
@@ -1,0 +1,4 @@
+module MyModule (example) where
+
+example :: String
+example = "example"

--- a/ghcid-ng/tests/data/simple/test/Main.hs
+++ b/ghcid-ng/tests/data/simple/test/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented."


### PR DESCRIPTION
Adds a simple Haskell project to the test data.

We will load this project in `ghci` to test `ghcid-ng`.