### PR TITLE
Add test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,14 +1747,32 @@ name = "test-harness"
 version = "0.1.0"
 dependencies = [
  "backoff",
+ "fs_extra",
  "itertools",
  "miette",
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
+ "test-harness-macro",
+ "test_bin",
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "test-harness-macro"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test_bin"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7a7de15468c6e65dd7db81cf3822c1ec94c71b2a3c1a976ea8e4696c91115c"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "fs_extra",
  "itertools",
  "miette",
+ "nix",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "ghcid-ng",
     "test-harness",
+    "test-harness-macro",
 ]
 
 resolver = "2"

--- a/flake.nix
+++ b/flake.nix
@@ -138,11 +138,9 @@
           inherit GHC_VERSIONS;
 
           # Any dev tools you use in excess of the rust ones
-          nativeBuildInputs =
-            [
-              pkgs.rust-analyzer
-            ]
-            ++ ghcBuildInputs;
+          nativeBuildInputs = [
+            pkgs.rust-analyzer
+          ];
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           [pkgs.haskellPackages.cabal-install]
           ++ ghcPackages;
 
-        fullGhcVersions = builtins.map (drv: drv.version) ghcPackages;
+        GHC_VERSIONS = builtins.map (drv: drv.version) ghcPackages;
 
         craneLib = crane.lib.${system};
 
@@ -81,7 +81,7 @@
             ];
 
             # Provide GHC versions to use to the integration test suite.
-            GHC_VERSIONS = fullGhcVersions;
+            inherit GHC_VERSIONS;
 
             cargoBuildCommand = "cargoWithProfile build --all";
             cargoCheckExtraArgs = "--all";
@@ -135,7 +135,7 @@
           RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
 
           # Provide GHC versions to use to the integration test suite.
-          GHC_VERSIONS = fullGhcVersions;
+          inherit GHC_VERSIONS;
 
           # Any dev tools you use in excess of the rust ones
           nativeBuildInputs =

--- a/flake.nix
+++ b/flake.nix
@@ -49,17 +49,13 @@
           "ghc96"
         ];
 
+        ghcPackages = builtins.map (ghcVersion: pkgs.haskell.compiler.${ghcVersion}) ghcVersions;
+
         ghcBuildInputs =
           [pkgs.haskellPackages.cabal-install]
-          ++ builtins.map (ghcVersion: pkgs.haskell.compiler.${ghcVersion}) ghcVersions;
+          ++ ghcPackages;
 
-        fullGhcVersions = builtins.map (drv: drv.version) (
-          builtins.filter (
-            drv:
-              drv.pname == "ghc"
-          )
-          ghcBuildInputs
-        );
+        fullGhcVersions = builtins.map (drv: drv.version) ghcPackages;
 
         craneLib = crane.lib.${system};
 

--- a/test-harness-macro/Cargo.toml
+++ b/test-harness-macro/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test-harness-macro"
+version = "0.1.0"
+edition = "2021"
+
+description = "Test attribute for ghcid-ng"
+
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.33"
+syn = { version = "2.0.29", features = ["full"] }

--- a/test-harness-macro/src/lib.rs
+++ b/test-harness-macro/src/lib.rs
@@ -29,7 +29,7 @@ pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
             .into(),
         )
-        .expect("Could not parse quoted attributes #[tokio::test] and #[tracing_test::traced_test]")
+        .expect("Could not parse quoted attributes")
         .0,
     );
 

--- a/test-harness-macro/src/lib.rs
+++ b/test-harness-macro/src/lib.rs
@@ -14,8 +14,6 @@ use syn::ItemFn;
 ///
 /// One test is generated for each GHC version listed in the `$GHC_VERSIONS` environment variable
 /// at compile-time.
-///
-/// This is designed to be used with [`test_harness::GhcidNg`].
 #[proc_macro_attribute]
 pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse annotated function

--- a/test-harness-macro/src/lib.rs
+++ b/test-harness-macro/src/lib.rs
@@ -96,7 +96,7 @@ fn make_test_fn(mut function: ItemFn, ghc_version: &str) -> ItemFn {
                             format!("{}::{}", module_path!(), #test_name),
                             ::std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
                         );
-                        ::test_harness::internal::cleanup_tempdir();
+                        ::test_harness::internal::cleanup().await;
 
                         if err.is_panic() {
                             ::std::panic::resume_unwind(err.into_panic());
@@ -105,7 +105,7 @@ fn make_test_fn(mut function: ItemFn, ghc_version: &str) -> ItemFn {
                         }
                     }
                     Ok(()) => {
-                        ::test_harness::internal::cleanup_tempdir();
+                        ::test_harness::internal::cleanup().await;
                     }
                 };
             }

--- a/test-harness-macro/src/lib.rs
+++ b/test-harness-macro/src/lib.rs
@@ -80,9 +80,6 @@ fn make_test_fn(mut function: ItemFn, ghc_version: &str) -> ItemFn {
     let new_body = parse::<Block>(
         quote! {
             {
-                ::test_harness::internal::IN_CUSTOM_TEST_HARNESS.with(|value| {
-                    value.store(true, ::std::sync::atomic::Ordering::SeqCst);
-                });
                 ::test_harness::internal::GHC_VERSION.with(|tmpdir| {
                     *tmpdir.borrow_mut() = #ghc_version.to_owned();
                 });

--- a/test-harness-macro/src/lib.rs
+++ b/test-harness-macro/src/lib.rs
@@ -1,0 +1,106 @@
+use proc_macro::TokenStream;
+
+use quote::quote;
+use quote::ToTokens;
+use syn::parse;
+use syn::parse::Parse;
+use syn::parse::ParseStream;
+use syn::Attribute;
+use syn::Block;
+use syn::Ident;
+use syn::ItemFn;
+
+/// GHC versions to run each test under.
+///
+/// Keep this synced with `../../flake.nix`.
+const GHC_VERSIONS: [&str; 4] = ["9.0.2", "9.2.8", "9.4.6", "9.6.2"];
+
+#[proc_macro_attribute]
+pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Parse annotated function
+    let mut function: ItemFn = parse(item).expect("Could not parse item as function");
+
+    function.attrs.extend(
+        parse::<Attributes>(
+            quote! {
+                #[tokio::test]
+                #[tracing_test::traced_test]
+                #[allow(non_snake_case)]
+            }
+            .into(),
+        )
+        .expect("Could not parse quoted attributes #[tokio::test] and #[tracing_test::traced_test]")
+        .0,
+    );
+
+    // Generate functions for each GHC version we want to test.
+    let mut ret = TokenStream::new();
+    for ghc_version in GHC_VERSIONS {
+        ret.extend::<TokenStream>(
+            make_test_fn(function.clone(), ghc_version)
+                .to_token_stream()
+                .into(),
+        );
+    }
+    ret
+}
+
+struct Attributes(Vec<Attribute>);
+
+impl Parse for Attributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self(input.call(Attribute::parse_outer)?))
+    }
+}
+
+fn make_test_fn(mut function: ItemFn, ghc_version: &str) -> ItemFn {
+    let ghc_version_ident = ghc_version.replace('.', "");
+    let stmts = function.block.stmts;
+    let test_name_base = function.sig.ident.to_string();
+    let test_name = format!("{test_name_base}_{ghc_version_ident}");
+    function.sig.ident = Ident::new(&test_name, function.sig.ident.span());
+
+    let new_body = parse::<Block>(
+        quote! {
+            {
+                ::test_harness::internal::IN_CUSTOM_TEST_HARNESS.with(|value| {
+                    value.store(true, ::std::sync::atomic::Ordering::SeqCst);
+                });
+                ::test_harness::internal::CARGO_TARGET_TMPDIR.with(|tmpdir| {
+                    *tmpdir.borrow_mut() = Some(::std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")));
+                });
+                ::test_harness::internal::GHC_VERSION.with(|tmpdir| {
+                    *tmpdir.borrow_mut() = #ghc_version.to_owned();
+                });
+
+                match ::tokio::task::spawn(async {
+                    #(#stmts);*
+                }).await {
+                    Err(err) => {
+                        // Copy out temp files
+                        ::test_harness::internal::save_test_logs(
+                            format!("{}::{}", module_path!(), #test_name)
+                        );
+                        ::test_harness::internal::cleanup_tempdir();
+
+                        if err.is_panic() {
+                            ::std::panic::resume_unwind(err.into_panic());
+                        } else {
+                            panic!("Test cancelled? {err:?}");
+                        }
+                    }
+                    Ok(()) => {
+                        ::test_harness::internal::cleanup_tempdir();
+                    }
+                };
+            }
+        }
+        .into(),
+    )
+    .expect("Could not parse function body");
+
+    // Replace function body
+    *function.block = new_body;
+
+    function
+}

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -10,6 +10,7 @@ backoff = { version = "0.4.0", default-features = false }
 fs_extra = "1.3.0"
 itertools = "0.11.0"
 miette = { version = "5.9.0", features = ["fancy"] }
+nix = { version = "0.26.2", default_features = false, features = ["process"] }
 regex = "1.9.4"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = "1.0.105"

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -7,10 +7,14 @@ publish = false
 
 [dependencies]
 backoff = { version = "0.4.0", default-features = false }
+fs_extra = "1.3.0"
 itertools = "0.11.0"
 miette = { version = "5.9.0", features = ["fancy"] }
 regex = "1.9.4"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = "1.0.105"
+tempfile = "3.8.0"
+test-harness-macro = { path = "../test-harness-macro" }
+test_bin = "0.4.0"
 tokio = { version = "1.28.2", features = ["full", "tracing"] }
 tracing = "0.1.37"

--- a/test-harness/src/fs.rs
+++ b/test-harness/src/fs.rs
@@ -15,7 +15,7 @@ use tokio::io::AsyncWriteExt;
 
 /// Touch a path.
 #[tracing::instrument]
-pub async fn touch(path: impl AsRef<Path> + Debug + Debug) -> miette::Result<()> {
+pub async fn touch(path: impl AsRef<Path> + Debug) -> miette::Result<()> {
     let path = path.as_ref();
     if let Some(parent) = path.parent() {
         create_dir(parent).await?;

--- a/test-harness/src/fs.rs
+++ b/test-harness/src/fs.rs
@@ -1,3 +1,5 @@
+//! Filesystem utilities for writing integration tests for `ghcid-ng`.
+
 use std::fmt::Display;
 use std::path::Path;
 use std::time::Duration;

--- a/test-harness/src/fs.rs
+++ b/test-harness/src/fs.rs
@@ -40,7 +40,7 @@ pub async fn append(path: impl AsRef<Path>, data: impl Display) -> miette::Resul
 
 /// Wait for a path to be created.
 ///
-/// This should generaly be run under a [`tokio::time::timeout`].
+/// This should generally be run under a [`tokio::time::timeout`].
 pub async fn wait_for_path(path: &Path) {
     let mut backoff = ExponentialBackoff {
         max_interval: Duration::from_secs(1),

--- a/test-harness/src/fs.rs
+++ b/test-harness/src/fs.rs
@@ -1,11 +1,12 @@
 //! Filesystem utilities for writing integration tests for `ghcid-ng`.
 
-use std::fmt::Display;
+use std::fmt::Debug;
 use std::path::Path;
 use std::time::Duration;
 
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
+use miette::miette;
 use miette::Context;
 use miette::IntoDiagnostic;
 use tokio::fs::File;
@@ -13,8 +14,12 @@ use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
 /// Touch a path.
-pub async fn touch(path: impl AsRef<Path>) -> miette::Result<()> {
+#[tracing::instrument]
+pub async fn touch(path: impl AsRef<Path> + Debug + Debug) -> miette::Result<()> {
     let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        create_dir(parent).await?;
+    }
     OpenOptions::new()
         .create(true)
         .write(true)
@@ -25,8 +30,22 @@ pub async fn touch(path: impl AsRef<Path>) -> miette::Result<()> {
         .map(|_| ())
 }
 
+/// Write some data to a path, replacing its previous contents.
+#[tracing::instrument(skip(data))]
+pub async fn write(path: impl AsRef<Path> + Debug, data: impl AsRef<[u8]>) -> miette::Result<()> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        create_dir(parent).await?;
+    }
+    tokio::fs::write(path, data)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to write {path:?}"))
+}
+
 /// Append some data to a path.
-pub async fn append(path: impl AsRef<Path>, data: impl Display) -> miette::Result<()> {
+#[tracing::instrument(skip(data))]
+pub async fn append(path: impl AsRef<Path> + Debug, data: impl AsRef<[u8]>) -> miette::Result<()> {
     let path = path.as_ref();
     let mut file = OpenOptions::new()
         .append(true)
@@ -34,15 +53,13 @@ pub async fn append(path: impl AsRef<Path>, data: impl Display) -> miette::Resul
         .await
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to open {path:?}"))?;
-    file.write_all(data.to_string().as_bytes())
-        .await
-        .into_diagnostic()?;
-    Ok(())
+    file.write_all(data.as_ref()).await.into_diagnostic()
 }
 
 /// Wait for a path to be created.
 ///
 /// This should generally be run under a [`tokio::time::timeout`].
+#[tracing::instrument]
 pub async fn wait_for_path(path: &Path) {
     let mut backoff = ExponentialBackoff {
         max_interval: Duration::from_secs(1),
@@ -55,4 +72,71 @@ pub async fn wait_for_path(path: &Path) {
         tracing::debug!("Waiting {duration:?} before retrying");
         tokio::time::sleep(duration).await;
     }
+}
+
+/// Read a path into a string.
+#[tracing::instrument]
+pub async fn read(path: impl AsRef<Path> + Debug) -> miette::Result<String> {
+    let path = path.as_ref();
+    tokio::fs::read_to_string(path)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to read {path:?}"))
+}
+
+/// Read from a path, run a string replacement on its contents, and then write the result.
+#[tracing::instrument(skip(from, to))]
+pub async fn replace(
+    path: impl AsRef<Path> + Debug,
+    from: impl AsRef<str>,
+    to: impl AsRef<str>,
+) -> miette::Result<()> {
+    let path = path.as_ref();
+    let old_contents = read(path).await?;
+    let new_contents = old_contents.replace(from.as_ref(), to.as_ref());
+    if old_contents == new_contents {
+        return Err(miette!(
+            "Replacing substring in file didn't make any changes"
+        ));
+    }
+    write(path, new_contents).await
+}
+
+/// Creates a directory and all of its parent components.
+#[tracing::instrument]
+pub async fn create_dir(path: impl AsRef<Path> + Debug) -> miette::Result<()> {
+    let path = path.as_ref();
+    tokio::fs::create_dir_all(path)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to create directory {path:?}"))
+}
+
+/// Remove the file or directory at the given path.
+///
+/// Directories are removed recursively; be careful.
+#[tracing::instrument]
+pub async fn remove(path: impl AsRef<Path> + Debug) -> miette::Result<()> {
+    let path = path.as_ref();
+    if path.is_dir() {
+        tokio::fs::remove_dir_all(path).await
+    } else {
+        tokio::fs::remove_file(path).await
+    }
+    .into_diagnostic()
+    .wrap_err_with(|| format!("Failed to remove {path:?}"))
+}
+
+/// Move the path at `from` to the path at `to`.
+#[tracing::instrument]
+pub async fn rename(
+    from: impl AsRef<Path> + Debug,
+    to: impl AsRef<Path> + Debug,
+) -> miette::Result<()> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    tokio::fs::rename(from, to)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to move {from:?} to {to:?}"))
 }

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -171,16 +171,13 @@ async fn write_cabal_config(home: &Path) -> miette::Result<()> {
 /// This is a nice check that the given GHC version is present in the environment, to fail tests
 /// early without waiting for `ghcid-ng` to fail.
 async fn check_ghc_version(home: &Path, ghc_version: &str) -> miette::Result<()> {
-    if Command::new(format!("ghc-{ghc_version}"))
+    let _output = Command::new(format!("ghc-{ghc_version}"))
         .env("HOME", home)
-        .status()
+        .output()
         .await
         .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to find GHC {ghc_version}"))?
-        .success()
-    {
-        Ok(())
-    } else {
-        Err(miette!("Could not execute `ghc-{ghc_version} --version`. Are you running the integration tests in the `nix develop` shell?"))
-    }
+        .wrap_err_with(|| format!("Failed to find GHC {ghc_version}"))?;
+    // `ghc --version` returns a nonzero status code. As long as we could actually execute it, it's
+    // OK if it failed.
+    Ok(())
 }

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -149,7 +149,7 @@ impl GhcidNg {
 
     /// Wait until `ghcid-ng` completes its initial load and is ready to receive file events.
     pub async fn wait_until_ready(&mut self) -> miette::Result<()> {
-        self.get_log(r"ghci started in \d+\.\d+m?s")
+        self.get_log_with_timeout(r"ghci started in \d+\.\d+m?s", Duration::from_secs(60))
             .await
             .wrap_err("ghcid-ng didn't start in time")?;
         // Only _after_ `ghci` starts up do we initialize the file watcher.

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -42,7 +42,6 @@ impl GhcidNg {
         project_directory: impl AsRef<Path>,
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
     ) -> miette::Result<Self> {
-        crate::internal::ensure_in_custom_test_harness()?;
         let ghc_version = crate::internal::get_ghc_version()?;
         let tempdir = crate::internal::set_tempdir()?;
         write_cabal_config(&tempdir).await?;

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -1,0 +1,186 @@
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use miette::miette;
+use miette::Context;
+use miette::IntoDiagnostic;
+use tokio::process::Child;
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::task;
+use tokio::task::JoinHandle;
+
+use crate::tracing_reader::TracingReader;
+use crate::Event;
+use crate::IntoMatcher;
+
+/// Where to write `ghcid-ng` logs written by integration tests, relative to the temporary
+/// directory created for the test.
+pub(crate) const LOG_FILENAME: &str = "ghcid-ng.json";
+
+/// `ghcid-ng` session for integration testing.
+///
+/// This handles copying a directory of files to a temporary directory, starting a `ghcid-ng`
+/// session, and asynchronously reading a stream of log events from its JSON log output.
+pub struct GhcidNg {
+    /// The current working directory of the `ghcid-ng` session.
+    cwd: PathBuf,
+    /// The `ghcid-ng` child process.
+    #[allow(dead_code)]
+    child: Child,
+    #[allow(dead_code)]
+    tracing_reader_handle: JoinHandle<miette::Result<()>>,
+    /// A stream of tracing events from `ghcid-ng`.
+    log_receiver: mpsc::Receiver<Event>,
+}
+
+impl GhcidNg {
+    /// Start a new `ghcid-ng` session in a copy of the given path.
+    pub async fn new(project_directory: impl AsRef<Path>) -> miette::Result<Self> {
+        Self::new_with_args(project_directory, std::iter::empty::<&str>()).await
+    }
+
+    /// Start a new `ghcid-ng` session in a copy of the given path.
+    ///
+    /// Also add the given arguments to the `ghcid-ng` invocation.
+    pub async fn new_with_args(
+        project_directory: impl AsRef<Path>,
+        args: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    ) -> miette::Result<Self> {
+        crate::internal::ensure_in_custom_test_harness()?;
+        let ghc_version = crate::internal::get_ghc_version()?;
+        let tempdir = crate::internal::set_tempdir()?;
+        write_cabal_config(&tempdir).await?;
+        check_ghc_version(&tempdir, &ghc_version).await?;
+
+        let project_directory = project_directory.as_ref();
+        tracing::info!("Copying project files");
+        fs_extra::copy_items(&[project_directory], &tempdir, &Default::default())
+            .into_diagnostic()
+            .wrap_err("Failed to copy project files")?;
+
+        let project_directory_name = project_directory
+            .file_name()
+            .ok_or_else(|| miette!("Path has no directory name: {project_directory:?}"))?;
+
+        let cwd = tempdir.join(project_directory_name);
+
+        let log_path = tempdir.join(LOG_FILENAME);
+
+        tracing::info!("Starting ghcid-ng");
+        let child = Command::new(test_bin::get_test_bin("ghcid-ng").get_program())
+            .arg("--log-json")
+            .arg(&log_path)
+            .args([
+                "--command",
+                &format!("cabal --offline v2-repl --with-compiler ghc-{ghc_version}"),
+                "--tracing-filter",
+                "ghcid_ng=debug",
+                "--trace-spans",
+                "new,close",
+            ])
+            .args(args)
+            .current_dir(&cwd)
+            .env("HOME", &tempdir)
+            .stdin(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .into_diagnostic()
+            .wrap_err("Failed to start `ghcid-ng`")?;
+
+        // Wait for `ghcid-ng` to create the `log_path`
+        tokio::time::timeout(Duration::from_secs(10), crate::fs::wait_for_path(&log_path))
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!("`ghcid-ng` didn't create log path {log_path:?} fast enough")
+            })?;
+
+        let (sender, receiver) = mpsc::channel(128);
+
+        let tracing_reader_handle =
+            task::spawn(TracingReader::new(sender, log_path.clone()).await?.run());
+
+        Ok(Self {
+            cwd,
+            child,
+            log_receiver: receiver,
+            tracing_reader_handle,
+        })
+    }
+
+    /// Wait until a matching log event is found.
+    ///
+    /// Errors if waiting for the event takes longer than the given `timeout`.
+    pub async fn get_log_with_timeout(
+        &mut self,
+        matcher: impl IntoMatcher,
+        timeout_duration: Duration,
+    ) -> miette::Result<Event> {
+        let matcher = matcher.into_matcher()?;
+
+        match tokio::time::timeout(timeout_duration, async {
+            while let Some(event) = self.log_receiver.recv().await {
+                println!("{event}");
+                if matcher.matches(&event) {
+                    return Some(event);
+                }
+            }
+            None
+        })
+        .await
+        {
+            Ok(Some(event)) => Ok(event),
+            Ok(None) => Err(miette!("Log task exited")),
+            Err(_) => Err(miette!("Waiting for a log message timed out")),
+        }
+    }
+
+    /// Wait until a matching log event is found, with a default 1-minute timeout.
+    pub async fn get_log(&mut self, matcher: impl IntoMatcher) -> miette::Result<Event> {
+        self.get_log_with_timeout(matcher, Duration::from_secs(60))
+            .await
+    }
+
+    /// Get a path relative to the project root.
+    pub fn path(&self, path: impl AsRef<Path>) -> PathBuf {
+        self.cwd.join(path)
+    }
+}
+
+/// Write an empty `~/.cabal/config` so that `cabal` doesn't try to access the internet.
+///
+/// See: <https://github.com/haskell/cabal/issues/6167>
+async fn write_cabal_config(home: &Path) -> miette::Result<()> {
+    std::fs::create_dir_all(home.join(".cabal"))
+        .into_diagnostic()
+        .wrap_err("Failed to create `.cabal` directory")?;
+    crate::fs::touch(home.join(".cabal/config"))
+        .await
+        .wrap_err("Failed to write empty `.cabal/config`")?;
+    Ok(())
+}
+
+/// Check that `ghc-{ghc_version} --version` executes successfully.
+///
+/// This is a nice check that the given GHC version is present in the environment, to fail tests
+/// early without waiting for `ghcid-ng` to fail.
+async fn check_ghc_version(home: &Path, ghc_version: &str) -> miette::Result<()> {
+    if Command::new(format!("ghc-{ghc_version}"))
+        .env("HOME", home)
+        .status()
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to find GHC {ghc_version}"))?
+        .success()
+    {
+        Ok(())
+    } else {
+        Err(miette!("Could not execute `ghc-{ghc_version} --version`. Are you running the integration tests in the `nix develop` shell?"))
+    }
+}

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -13,6 +13,7 @@ use tokio::process::Command;
 use crate::tracing_reader::TracingReader;
 use crate::Event;
 use crate::IntoMatcher;
+use crate::Matcher;
 
 /// Where to write `ghcid-ng` logs written by integration tests, relative to the temporary
 /// directory created for the test.

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -85,7 +85,6 @@ impl GhcidNg {
             .stdout(Stdio::piped())
             .kill_on_drop(true);
 
-        #[cfg(target_os = "macos")]
         command.args(["--poll", "1000ms"]);
 
         let child = command

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -59,8 +59,13 @@ pub fn save_test_logs(test_name: String, cargo_target_tmpdir: PathBuf) {
 /// functions.
 pub fn cleanup_tempdir() {
     TEMPDIR.with(|path| {
-        std::fs::remove_dir_all(path.borrow().as_deref().expect("`TEMPDIR` is not set"))
-            .expect("Failed to clean up `TEMPDIR`");
+        let borrowed_path = path.borrow();
+        let path = borrowed_path.as_deref().expect("`TEMPDIR` is not set");
+        if let Err(err) = std::fs::remove_dir_all(path) {
+            // Run `find` on the directory so we can see what's in it?
+            let _status = std::process::Command::new("find").arg(path).status();
+            panic!("Failed to remove TEMPDIR: {path:?}\n{err}");
+        }
     });
 }
 

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -147,9 +147,9 @@ async fn cleanup() {
                     .status()
                     .await;
                 if path.exists() {
-                    tracing::error!("Failed to remove TEMPDIR: {path:?}\n{err}");
+                    panic!("Failed to remove TEMPDIR: {path:?}\n{err}");
                 } else {
-                    tracing::warn!("Failed to remove TEMPDIR with `remove_dir_all`, but `rm -rf` worked: {path:?}\n{err}");
+                    panic!("Failed to remove TEMPDIR with `remove_dir_all`, but `rm -rf` worked: {path:?}\n{err}");
                 }
             }
         }

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -19,8 +19,7 @@ thread_local! {
     pub(crate) static TEMPDIR: RefCell<Option<PathBuf>> = RefCell::new(None);
 
     /// The GHC version to use for this test. This should be a string like `ghc962`.
-    /// This is used to open a corresponding (e.g.) `nix develop .#ghc962` shell to run `ghcid-ng`
-    /// in.
+    /// This is used to select the correct GHC version to run.
     pub(crate) static GHC_VERSION: RefCell<String> = RefCell::new(String::new());
 
     /// The GHC process for this test.

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -1,0 +1,119 @@
+//! Internal functions, exposed for the `#[test]` attribute macro.
+
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::SeqCst;
+
+use miette::miette;
+use miette::Context;
+use miette::IntoDiagnostic;
+
+thread_local! {
+    /// The temporary directory where `ghcid-ng` is run. Note that because tests are run with the
+    /// `tokio` current-thread runtime, this is unique per-test.
+    pub static TEMPDIR: RefCell<Option<PathBuf>> = RefCell::new(None);
+
+    /// Directory to put failed test logs in. The `#[test]` attribute sets this at the start of the
+    /// test to the value of the compile-time environment variable `$CARGO_TARGET_TMPDIR`.
+    /// See: <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
+    pub static CARGO_TARGET_TMPDIR: RefCell<Option<PathBuf>> = RefCell::new(None);
+
+    /// The GHC version to use for this test. This should be a string like `ghc962`.
+    /// This is used to open a corresponding (e.g.) `nix develop .#ghc962` shell to run `ghcid-ng`
+    /// in.
+    pub static GHC_VERSION: RefCell<String> = RefCell::new(String::new());
+
+    /// Is this thread running in the custom test harness?
+    /// If `GhcidNg::new` was used outside of our custom test harness, the temporary directory
+    /// wouldn't be cleaned up -- this lets us detect that case and error to avoid it.
+    pub static IN_CUSTOM_TEST_HARNESS: AtomicBool = const { AtomicBool::new(false) };
+}
+
+/// Save the test logs in `TEMPDIR` to `CARGO_TARGET_TMPDIR`.
+///
+/// This is called when a `#[test]`-annotated function panics, to persist the logs for further
+/// analysis.
+pub fn save_test_logs(test_name: String) {
+    let log_path: PathBuf = TEMPDIR.with(|tempdir| {
+        tempdir
+            .borrow()
+            .as_deref()
+            .map(|path| path.join(crate::ghcid_ng::LOG_FILENAME))
+            .expect("`test_harness::TEMPDIR` is not set")
+    });
+    let persist_to = CARGO_TARGET_TMPDIR.with(|dir| {
+        dir.borrow()
+            .clone()
+            .expect("`CARGO_TARGET_TMPDIR` is not set")
+    });
+
+    let test_name = test_name.replace("::", "-");
+    let persist_log_path = persist_to.join(format!("{test_name}.json"));
+    if persist_log_path.exists() {
+        // Cargo doesn't manage `CARGO_TARGET_TMPDIR` for us, so we remove output from old tests
+        // ourself.
+        std::fs::remove_file(&persist_log_path).expect("Failed to remove log output");
+    }
+
+    if !log_path.exists() {
+        eprintln!("No logs were written");
+    } else {
+        let logs = std::fs::read_to_string(log_path).expect("Failed to read logs");
+        std::fs::write(&persist_log_path, logs).expect("Failed to write logs");
+        eprintln!("Wrote logs to {}", persist_log_path.display());
+    }
+}
+
+/// Remove the [`TEMPDIR`] from the filesystem. This is called at the end of `#[test]`-annotated
+/// functions.
+pub fn cleanup_tempdir() {
+    TEMPDIR.with(|path| {
+        std::fs::remove_dir_all(path.borrow().as_deref().expect("`TEMPDIR` is not set"))
+            .expect("Failed to clean up `TEMPDIR`");
+    });
+}
+
+/// Fail if [`IN_CUSTOM_TEST_HARNESS`] has not been set.
+pub(crate) fn ensure_in_custom_test_harness() -> miette::Result<()> {
+    if IN_CUSTOM_TEST_HARNESS.with(|value| value.load(SeqCst)) {
+        Ok(())
+    } else {
+        Err(miette!(
+            "`GhcidNg` can only be used in `#[test_harness::test]` functions"
+        ))
+    }
+}
+
+/// Get the GHC version as given by [`GHC_VERSION`].
+pub(crate) fn get_ghc_version() -> miette::Result<String> {
+    let ghc_version = GHC_VERSION.with(|version| version.borrow().to_owned());
+    if ghc_version.is_empty() {
+        Err(miette!("`GHC_VERSION` should be set"))
+    } else {
+        Ok(ghc_version)
+    }
+}
+
+/// Create a new temporary directory and set [`TEMPDIR`] to it, persisting it to disk.
+///
+/// Fails if [`TEMPDIR`] is already set.
+pub(crate) fn set_tempdir() -> miette::Result<PathBuf> {
+    let tempdir = tempfile::tempdir()
+        .into_diagnostic()
+        .wrap_err("Failed to create temporary directory")?;
+
+    // Set the thread-local tempdir for cleanup later.
+    TEMPDIR.with(|thread_tempdir| {
+        if thread_tempdir.borrow().is_some() {
+            return Err(miette!(
+                "`GhcidNg` can only be constructed once per `#[test_harness::test]` function"
+            ));
+        }
+        *thread_tempdir.borrow_mut() = Some(tempdir.path().to_path_buf());
+        Ok(())
+    })?;
+
+    // Now we can persist the tempdir to disk, knowing the test harness will clean it up later.
+    Ok(tempdir.into_path())
+}

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -60,7 +60,8 @@ pub fn save_test_logs(test_name: String, cargo_target_tmpdir: PathBuf) {
 
 /// Perform end-of-test cleanup.
 ///
-/// 1. Remove the [`TEMPDIR`] from the filesystem.
+/// 1. Kill the [`GHC_PROCESS`].
+/// 2. Remove the [`TEMPDIR`] from the filesystem.
 pub async fn cleanup() {
     let child = GHC_PROCESS.with(|child| child.take());
     match child {

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -142,7 +142,7 @@ async fn cleanup() {
                     .await;
                 // Try an `rm -rf` for good luck :)
                 let _status = tokio::process::Command::new("rm")
-                    .arg("-rf")
+                    .args(["-rf", "--"])
                     .arg(&path)
                     .status()
                     .await;

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -13,6 +13,8 @@ pub mod fs;
 
 pub mod internal;
 
+/// Marks a function as an `async` test for use with a [`GhcidNg`] session.
+///
 pub use test_harness_macro::test;
 
 mod ghcid_ng;

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -1,3 +1,5 @@
+//! Test harness library for `ghcid-ng` integration tests.
+
 mod tracing_json;
 pub use tracing_json::Event;
 
@@ -8,3 +10,10 @@ pub use matcher::IntoMatcher;
 pub use matcher::Matcher;
 
 pub mod fs;
+
+pub mod internal;
+
+pub use test_harness_macro::test;
+
+mod ghcid_ng;
+pub use ghcid_ng::GhcidNg;

--- a/test-harness/src/tracing_reader.rs
+++ b/test-harness/src/tracing_reader.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::path::Path;
 use std::time::Duration;
 
@@ -38,7 +36,10 @@ impl TracingReader {
         Ok(Self { lines })
     }
 
-    async fn next_event(&mut self) -> miette::Result<Event> {
+    /// Read the next event from the contained file.
+    ///
+    /// This will block indefinitely until a line is written to the contained file.
+    pub async fn next_event(&mut self) -> miette::Result<Event> {
         let mut backoff = ExponentialBackoff {
             max_elapsed_time: None,
             max_interval: Duration::from_secs(1),


### PR DESCRIPTION
The `GhcidNg` type copies a given directory to a tempdir and then launches `ghcid-ng` there. It also spawns an async task to read JSON log events from the log file.

`GhcidNg` uses thread-local storage to determine which version of `ghc` to use when launching tests, and will error appropriately if the thread-local storage is not set. This takes advantage of the fact that async tests run in the `tokio` "current-thread" runtime by default, which schedules all tasks in the test on the same thread.

The second part is a proc macro attribute exported as `#[test_harness::test]`, which rewrites tests so that

1. The tests are async functions which run under the default `#[tokio::test]` current-thread runtime.
2. Tracing is set up in the tests so that log messages from the `test-harness` library are visible in the test output.
3. The appropriate thread-local variables are set for each test (this includes the current GHC version).
4. One test is generated for each GHC version.
5. If tests fail, the relevant `ghcid-ng` logs are saved to a directory under `target/` and the path is printed at the end of the tests.

Here's a sample test from #44 using this test harness:

```rust
/// Test that `ghcid-ng` can start up and then reload on changes.
#[test]
async fn can_reload() {
    let mut session = GhcidNg::new("tests/data/simple")
        .await
        .expect("ghcid-ng starts");
    session
        .wait_until_ready()
        .await
        .expect("ghcid-ng loads ghci");
    fs::append(session.path("src/MyLib.hs"), "\n\nhello = 1\n")
        .await
        .unwrap();
    session
        .wait_until_reload()
        .await
        .expect("ghcid-ng reloads on changes");
    session
        .get_log(
            Matcher::span_close()
                .in_module("ghcid_ng::ghci")
                .in_spans(["on_action", "reload"]),
        )
        .await
        .expect("ghcid-ng finishes reloading");
}
```