### PR TITLE
Add tracing JSON reader to test-harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata 0.3.6",
+ "regex-automata 0.3.7",
  "serde",
 ]
 
@@ -224,9 +224,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
+checksum = "7c8d502cbaec4595d2e7d5f61e318f05417bd2b66fdc3809498f0d3fdf0bea27"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
+checksum = "5891c7bc0edb3e1c2204fc5e94009affabeb1821c9e5fdc3959536c5c0bb984d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -936,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.8",
+ "rustix 0.38.10",
  "windows-sys 0.48.0",
 ]
 
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "76fc44e2588d5b436dbc3c6cf62aef290f90dab6235744a93dfe1cc18f451e2c"
 
 [[package]]
 name = "memmap2"
@@ -1124,16 +1124,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset",
  "pin-utils",
- "static_assertions",
 ]
 
 [[package]]
@@ -1427,14 +1426,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.3.7",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1448,13 +1447,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1465,9 +1464,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustc-demangle"
@@ -1491,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -1525,18 +1524,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1622,12 +1621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strip-ansi-escapes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,7 +1699,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.38.8",
+ "rustix 0.38.10",
  "windows-sys 0.48.0",
 ]
 
@@ -1748,7 +1741,10 @@ name = "test-harness"
 version = "0.1.0"
 dependencies = [
  "backoff",
+ "itertools",
  "miette",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]
@@ -1808,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "itoa",
@@ -1829,9 +1825,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
 dependencies = [
  "time-core",
 ]

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 
 [dependencies]
 backoff = { version = "0.4.0", default-features = false }
+itertools = "0.11.0"
 miette = { version = "5.9.0", features = ["fancy"] }
+serde = { version = "1.0.186", features = ["derive"] }
+serde_json = "1.0.105"
 tokio = { version = "1.28.2", features = ["full", "tracing"] }
 tracing = "0.1.37"

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -1,1 +1,6 @@
+mod tracing_json;
+pub use tracing_json::Event;
+
+mod tracing_reader;
+
 pub mod fs;

--- a/test-harness/src/tracing_json.rs
+++ b/test-harness/src/tracing_json.rs
@@ -6,15 +6,23 @@ use miette::IntoDiagnostic;
 use serde::Deserialize;
 use tracing::Level;
 
+/// A [`tracing`] log event, deserialized from JSON log output.
 #[derive(Deserialize, Debug)]
 #[serde(try_from = "JsonEvent")]
 pub struct Event {
+    /// The event timestamp.
     pub timestamp: String,
+    /// The level the event was logged at.
     pub level: Level,
+    /// The log message. May be a span lifecycle event like `new` or `close`.
     pub message: String,
+    /// The event fields; extra data attached to this event.
     pub fields: HashMap<String, serde_json::Value>,
+    /// The target, usually the module where the event was logged from.
     pub target: String,
+    /// The span the event was logged in, if any.
     pub span: Option<Span>,
+    /// Spans the event is nested in, beyond the first `span`.
     pub spans: Vec<Span>,
 }
 
@@ -71,9 +79,12 @@ struct JsonEvent {
     spans: Vec<Span>,
 }
 
+/// A span (a region containing log events and other spans).
 #[derive(Deserialize, Debug)]
 pub struct Span {
+    /// The span's name.
     pub name: String,
+    /// The span's fields; extra data attached to this span.
     #[serde(flatten)]
     pub rest: HashMap<String, serde_json::Value>,
 }

--- a/test-harness/src/tracing_json.rs
+++ b/test-harness/src/tracing_json.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use miette::Context;
+use miette::IntoDiagnostic;
+use serde::Deserialize;
+use tracing::Level;
+
+#[derive(Deserialize, Debug)]
+#[serde(try_from = "JsonEvent")]
+pub struct Event {
+    pub timestamp: String,
+    pub level: Level,
+    pub message: String,
+    pub fields: HashMap<String, serde_json::Value>,
+    pub target: String,
+    pub span: Option<Span>,
+    pub spans: Vec<Span>,
+}
+
+impl Event {
+    /// Get an iterator over this event's spans, from the inside out.
+    pub fn spans(&self) -> impl Iterator<Item = &Span> {
+        self.span.iter().chain(self.spans.iter())
+    }
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.level, self.target)?;
+        let spans = itertools::join(self.spans(), ">");
+        if !spans.is_empty() {
+            write!(f, " [{spans}]")?;
+        }
+        write!(f, ": {}", self.message)?;
+        if !self.fields.is_empty() {
+            write!(f, " {}", display_map(&self.fields))?;
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<JsonEvent> for Event {
+    type Error = miette::Report;
+
+    fn try_from(event: JsonEvent) -> Result<Self, Self::Error> {
+        Ok(Self {
+            timestamp: event.timestamp,
+            level: event
+                .level
+                .parse()
+                .into_diagnostic()
+                .wrap_err_with(|| format!("Failed to parse tracing level: {}", event.level))?,
+            message: event.fields.message,
+            fields: event.fields.rest,
+            target: event.target,
+            span: event.span,
+            spans: event.spans,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct JsonEvent {
+    timestamp: String,
+    level: String,
+    fields: Fields,
+    target: String,
+    span: Option<Span>,
+    #[serde(default)]
+    spans: Vec<Span>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Span {
+    pub name: String,
+    #[serde(flatten)]
+    pub rest: HashMap<String, serde_json::Value>,
+}
+
+impl Display for Span {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.name, display_map(&self.rest))
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct Fields {
+    message: String,
+    #[serde(flatten)]
+    rest: HashMap<String, serde_json::Value>,
+}
+
+fn display_map(hashmap: &HashMap<String, serde_json::Value>) -> String {
+    if hashmap.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "{{{}}}",
+            itertools::join(
+                hashmap
+                    .iter()
+                    .map(|(name, value)| format!("{name}={value}")),
+                ", ",
+            )
+        )
+    }
+}

--- a/test-harness/src/tracing_reader.rs
+++ b/test-harness/src/tracing_reader.rs
@@ -22,6 +22,8 @@ pub struct TracingReader {
 }
 
 impl TracingReader {
+    /// Create a new [`TracingReader`], sending log events to the given `sender` after they're
+    /// written to the given `path`.
     pub async fn new(sender: mpsc::Sender<Event>, path: impl AsRef<Path>) -> miette::Result<Self> {
         let path = path.as_ref();
 
@@ -35,6 +37,7 @@ impl TracingReader {
         Ok(Self { sender, lines })
     }
 
+    /// Run this task.
     #[instrument(skip(self), name = "json-reader", level = "debug")]
     pub async fn run(mut self) -> miette::Result<()> {
         loop {

--- a/test-harness/src/tracing_reader.rs
+++ b/test-harness/src/tracing_reader.rs
@@ -1,0 +1,73 @@
+use std::path::Path;
+use std::time::Duration;
+
+use backoff::backoff::Backoff;
+use backoff::ExponentialBackoff;
+use miette::Context;
+use miette::IntoDiagnostic;
+use tokio::fs::File;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
+use tokio::io::Lines;
+use tokio::sync::mpsc;
+use tracing::instrument;
+
+use super::Event;
+
+/// A task to read JSON tracing log events output by `ghid-ng` and send them over a channel.
+#[allow(dead_code)]
+pub struct TracingReader {
+    sender: mpsc::Sender<Event>,
+    lines: Lines<BufReader<File>>,
+}
+
+impl TracingReader {
+    pub async fn new(sender: mpsc::Sender<Event>, path: impl AsRef<Path>) -> miette::Result<Self> {
+        let path = path.as_ref();
+
+        let file = File::open(path)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to open {path:?}"))?;
+
+        let lines = BufReader::new(file).lines();
+
+        Ok(Self { sender, lines })
+    }
+
+    #[instrument(skip(self), name = "json-reader", level = "debug")]
+    pub async fn run(mut self) -> miette::Result<()> {
+        loop {
+            match self.run_inner().await {
+                Ok(()) => {
+                    // Graceful shutdown
+                    tracing::debug!("JSON reader exiting");
+                    break;
+                }
+                Err(err) => {
+                    tracing::error!("{err:?}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn run_inner(&mut self) -> miette::Result<()> {
+        let mut backoff = ExponentialBackoff {
+            max_elapsed_time: None,
+            max_interval: Duration::from_secs(1),
+            ..Default::default()
+        };
+
+        while let Some(duration) = backoff.next_backoff() {
+            while let Some(line) = self.lines.next_line().await.into_diagnostic()? {
+                let event = serde_json::from_str(&line).into_diagnostic()?;
+                self.sender.send(event).await.into_diagnostic()?;
+            }
+            tokio::time::sleep(duration).await;
+        }
+
+        Ok(())
+    }
+}

--- a/test-harness/src/tracing_reader.rs
+++ b/test-harness/src/tracing_reader.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::path::Path;
 use std::time::Duration;
 
@@ -9,15 +11,11 @@ use tokio::fs::File;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use tokio::io::Lines;
-use tokio::sync::mpsc;
-use tracing::instrument;
 
 use super::Event;
 
 /// A task to read JSON tracing log events output by `ghid-ng` and send them over a channel.
-#[allow(dead_code)]
 pub struct TracingReader {
-    sender: mpsc::Sender<Event>,
     lines: Lines<BufReader<File>>,
 }
 
@@ -27,7 +25,7 @@ impl TracingReader {
     /// This watches for data to be read from the given `path`. When a line is written to `path`
     /// (by `ghcid-ng`), the `TracingReader` will deserialize the line from JSON into an [`Event`]
     /// and send it to the given `sender` for another task to receive.
-    pub async fn new(sender: mpsc::Sender<Event>, path: impl AsRef<Path>) -> miette::Result<Self> {
+    pub async fn new(path: impl AsRef<Path>) -> miette::Result<Self> {
         let path = path.as_ref();
 
         let file = File::open(path)
@@ -37,29 +35,10 @@ impl TracingReader {
 
         let lines = BufReader::new(file).lines();
 
-        Ok(Self { sender, lines })
+        Ok(Self { lines })
     }
 
-    /// Run this task.
-    #[instrument(skip(self), name = "json-reader", level = "debug")]
-    pub async fn run(mut self) -> miette::Result<()> {
-        loop {
-            match self.run_inner().await {
-                Ok(()) => {
-                    // Graceful shutdown
-                    tracing::debug!("JSON reader exiting");
-                    break;
-                }
-                Err(err) => {
-                    tracing::error!("{err:?}");
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn run_inner(&mut self) -> miette::Result<()> {
+    async fn next_event(&mut self) -> miette::Result<Event> {
         let mut backoff = ExponentialBackoff {
             max_elapsed_time: None,
             max_interval: Duration::from_secs(1),
@@ -67,13 +46,13 @@ impl TracingReader {
         };
 
         while let Some(duration) = backoff.next_backoff() {
-            while let Some(line) = self.lines.next_line().await.into_diagnostic()? {
+            if let Some(line) = self.lines.next_line().await.into_diagnostic()? {
                 let event = serde_json::from_str(&line).into_diagnostic()?;
-                self.sender.send(event).await.into_diagnostic()?;
+                return Ok(event);
             }
             tokio::time::sleep(duration).await;
         }
 
-        Ok(())
+        unreachable!()
     }
 }

--- a/test-harness/src/tracing_reader.rs
+++ b/test-harness/src/tracing_reader.rs
@@ -22,8 +22,11 @@ pub struct TracingReader {
 }
 
 impl TracingReader {
-    /// Create a new [`TracingReader`], sending log events to the given `sender` after they're
-    /// written to the given `path`.
+    /// Create a new [`TracingReader`].
+    ///
+    /// This watches for data to be read from the given `path`. When a line is written to `path`
+    /// (by `ghcid-ng`), the `TracingReader` will deserialize the line from JSON into an [`Event`]
+    /// and send it to the given `sender` for another task to receive.
     pub async fn new(sender: mpsc::Sender<Event>, path: impl AsRef<Path>) -> miette::Result<Self> {
         let path = path.as_ref();
 


### PR DESCRIPTION
The Tracing JSON reader is an async task which will wait for `ghcid-ng` to write tracing log events to a file, deserialize them, and make them available to the test harness.

This is the core of the tests; `ghcid-ng` is started, we wait for a particular log event, we make changes with the IO helpers, repeat.