### PR TITLE
Add tracing event matcher to test-harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,6 +1743,7 @@ dependencies = [
  "backoff",
  "itertools",
  "miette",
+ "regex",
  "serde",
  "serde_json",
  "tokio",

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 backoff = { version = "0.4.0", default-features = false }
 itertools = "0.11.0"
 miette = { version = "5.9.0", features = ["fancy"] }
+regex = "1.9.4"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = "1.0.105"
 tokio = { version = "1.28.2", features = ["full", "tracing"] }

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -3,4 +3,8 @@ pub use tracing_json::Event;
 
 mod tracing_reader;
 
+mod matcher;
+pub use matcher::IntoMatcher;
+pub use matcher::Matcher;
+
 pub mod fs;

--- a/test-harness/src/matcher.rs
+++ b/test-harness/src/matcher.rs
@@ -59,7 +59,7 @@ impl Matcher {
     ///
     /// Note that this requires the module name to match exactly; child modules will not be
     /// matched.
-    pub fn from_module(mut self, module: &str) -> Self {
+    pub fn in_module(mut self, module: &str) -> Self {
         self.target = Some(module.to_owned());
         self
     }
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn test_matcher_spans_and_target() {
         let matcher = Matcher::span_close()
-            .from_module("ghcid_ng::ghci")
+            .in_module("ghcid_ng::ghci")
             .in_spans(["reload", "on_action"]);
         let event = Event {
             timestamp: "2023-08-25T22:14:30.993920Z".to_owned(),

--- a/test-harness/src/matcher.rs
+++ b/test-harness/src/matcher.rs
@@ -1,0 +1,167 @@
+use miette::IntoDiagnostic;
+use regex::Regex;
+
+use crate::Event;
+
+/// An [`Event`] matcher.
+pub struct Matcher {
+    message: Regex,
+    target: Option<String>,
+    spans: Vec<String>,
+}
+
+impl Matcher {
+    /// Construct a query for events with messages matching the given regex.
+    pub fn message(message_regex: &str) -> miette::Result<Self> {
+        let message = Regex::new(message_regex).into_diagnostic()?;
+        Ok(Self {
+            message,
+            target: None,
+            spans: Vec::new(),
+        })
+    }
+
+    /// Construct a query for new span events, denoted by a `new` message.
+    pub fn span_new() -> Self {
+        // This regex will never fail to parse.
+        Self::message("new").unwrap()
+    }
+
+    /// Construct a query for span close events, denoted by a `close` message.
+    pub fn span_close() -> Self {
+        // This regex will never fail to parse.
+        Self::message("close").unwrap()
+    }
+
+    /// Require that matching events be in a span with the given name.
+    ///
+    /// Note that this will overwrite any previously-set spans.
+    pub fn in_span(mut self, span: &str) -> Self {
+        self.spans.clear();
+        self.spans.push(span.to_owned());
+        self
+    }
+
+    /// Require that matching events be in spans with the given names.
+    ///
+    /// Spans are listed from the inside out; that is, a call to `in_spans(["a", "b", "c"])` will
+    /// require that events be emitted from a span `a` directly nested in a span
+    /// `b` directly nested in a span `c`.
+    ///
+    /// Note that this will overwrite any previously-set spans.
+    pub fn in_spans(mut self, spans: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
+        self.spans = spans.into_iter().map(|s| s.as_ref().to_owned()).collect();
+        self
+    }
+
+    /// Require that matching events be emitted from the given module as recorded by the event's
+    /// `target` field.
+    ///
+    /// Note that this requires the module name to match exactly; child modules will not be
+    /// matched.
+    pub fn from_module(mut self, module: &str) -> Self {
+        self.target = Some(module.to_owned());
+        self
+    }
+
+    /// Determines if this query matches the given event.
+    pub fn matches(&self, event: &Event) -> bool {
+        if !self.message.is_match(&event.message) {
+            return false;
+        }
+
+        if !self.spans.is_empty() {
+            let mut spans = event.spans();
+            for expected_name in &self.spans {
+                match spans.next() {
+                    Some(actual_span) => {
+                        if &actual_span.name != expected_name {
+                            return false;
+                        }
+                    }
+                    None => {
+                        // We expected another span but the event doesn't have one.
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if let Some(target) = &self.target {
+            if target != &event.target {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// A type that can be converted into a `Matcher` and used for searching log events.
+pub trait IntoMatcher {
+    /// Convert the object into a `Matcher`.
+    fn into_matcher(self) -> miette::Result<Matcher>;
+}
+
+impl IntoMatcher for Matcher {
+    fn into_matcher(self) -> miette::Result<Matcher> {
+        Ok(self)
+    }
+}
+
+impl IntoMatcher for &str {
+    fn into_matcher(self) -> miette::Result<Matcher> {
+        Matcher::message(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::Level;
+
+    use crate::tracing_json::Span;
+
+    use super::*;
+
+    #[test]
+    fn test_matcher_message() {
+        let matcher = r"ghci started in \d+\.\d+s".into_matcher().unwrap();
+        assert!(matcher.matches(&Event {
+            timestamp: "2023-08-25T22:14:30.067641Z".to_owned(),
+            level: Level::INFO,
+            message: "ghci started in 2.44s".to_owned(),
+            fields: Default::default(),
+            target: "ghcid_ng::ghci".to_owned(),
+            span: Some(Span {
+                name: "ghci".to_owned(),
+                rest: Default::default()
+            }),
+            spans: vec![Span {
+                name: "ghci".to_owned(),
+                rest: Default::default()
+            },]
+        }));
+    }
+
+    #[test]
+    fn test_matcher_spans_and_target() {
+        let matcher = Matcher::span_close()
+            .from_module("ghcid_ng::ghci")
+            .in_spans(["reload", "on_action"]);
+        assert!(matcher.matches(&Event {
+            timestamp: "2023-08-25T22:14:30.993920Z".to_owned(),
+            level: Level::DEBUG,
+            message: "close".to_owned(),
+            fields: Default::default(),
+            target: "ghcid_ng::ghci".to_owned(),
+            span: Some(Span {
+                name: "reload".to_owned(),
+                rest: Default::default()
+            }),
+            spans: vec![Span {
+                name: "on_action".to_owned(),
+                rest: Default::default()
+            },]
+        }));
+    }
+}

--- a/test-harness/src/tracing_json.rs
+++ b/test-harness/src/tracing_json.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use tracing::Level;
 
 /// A [`tracing`] log event, deserialized from JSON log output.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(try_from = "JsonEvent")]
 pub struct Event {
     /// The event timestamp.
@@ -80,7 +80,7 @@ struct JsonEvent {
 }
 
 /// A span (a region containing log events and other spans).
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Span {
     /// The span's name.
     pub name: String,

--- a/test-harness/src/tracing_json.rs
+++ b/test-harness/src/tracing_json.rs
@@ -89,6 +89,16 @@ pub struct Span {
     pub rest: HashMap<String, serde_json::Value>,
 }
 
+impl Span {
+    #[cfg(test)]
+    pub fn new(name: impl Display) -> Self {
+        Self {
+            name: name.to_string(),
+            rest: Default::default(),
+        }
+    }
+}
+
 impl Display for Span {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}{}", self.name, display_map(&self.rest))


### PR DESCRIPTION
The event matcher is an API which test authors can use to request that the test waits until a certain log message is seen. Logs can be matched based on the spans they're contained in, the module they originated from, and a regular expression match on the log message.