### PR TITLE
Release version 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "ghcid-ng"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aho-corasick",
  "backoff",

--- a/ghcid-ng/Cargo.toml
+++ b/ghcid-ng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghcid-ng"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = [
     "Rebecca Turner <rebeccat@mercury.com>"


### PR DESCRIPTION
Update version to 0.3.1 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.