### PR TITLE
Parse shell command arguments

### DIFF
--- a/ghcid-ng/src/clap/clonable_command.rs
+++ b/ghcid-ng/src/clap/clonable_command.rs
@@ -1,0 +1,35 @@
+use clap::builder::StringValueParser;
+use clap::builder::TypedValueParser;
+use clap::builder::ValueParserFactory;
+
+use crate::command::ClonableCommand;
+
+/// [`clap`] parser for [`ClonableCommand`] values.
+#[derive(Default, Clone)]
+pub struct ClonableCommandParser {
+    inner: StringValueParser,
+}
+
+impl TypedValueParser for ClonableCommandParser {
+    type Value = ClonableCommand;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        self.inner.parse_ref(cmd, arg, value).and_then(|str| {
+            crate::command::from_string(&str)
+                .map_err(|err| super::value_validation_error(arg, &str, format!("{err:?}")))
+        })
+    }
+}
+
+impl ValueParserFactory for ClonableCommand {
+    type Parser = ClonableCommandParser;
+
+    fn value_parser() -> Self::Parser {
+        Self::Parser::default()
+    }
+}

--- a/ghcid-ng/src/clap/mod.rs
+++ b/ghcid-ng/src/clap/mod.rs
@@ -1,6 +1,7 @@
 //! Adapters for parsing [`clap`] arguments to various types.
 
 mod camino;
+mod clonable_command;
 mod error_message;
 mod fmt_span;
 mod humantime;

--- a/ghcid-ng/src/cli.rs
+++ b/ghcid-ng/src/cli.rs
@@ -9,6 +9,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 
 use crate::clap::FmtSpanParserFactory;
 use crate::clap::RustBacktrace;
+use crate::command::ClonableCommand;
 
 /// A `ghci`-based file watcher and Haskell recompiler.
 #[derive(Debug, Clone, Parser)]
@@ -21,18 +22,12 @@ pub struct Opts {
     ///
     /// May contain quoted arguments which will be parsed in a `sh`-like manner.
     #[arg(long, value_name = "SHELL_COMMAND")]
-    pub command: Option<String>,
+    pub command: Option<ClonableCommand>,
 
     /// A `ghci` command which runs tests, like `TestMain.testMain`. If given, this command will be
     /// run after reloads.
     #[arg(long, value_name = "GHCI_COMMAND")]
     pub test_ghci: Option<String>,
-
-    /// Shell commands to run before starting or restarting `ghci`.
-    ///
-    /// This can be used to regenerate `.cabal` files with `hpack`.
-    #[arg(long, value_name = "SHELL_COMMAND")]
-    pub before_startup_shell: Vec<String>,
 
     /// `ghci` commands to run on startup. Use `:set args ...` in combination with `--test` to set
     /// the command-line arguments for tests.

--- a/ghcid-ng/src/cli.rs
+++ b/ghcid-ng/src/cli.rs
@@ -17,19 +17,27 @@ use crate::clap::RustBacktrace;
 pub struct Opts {
     /// A shell command which starts a `ghci` REPL, e.g. `ghci` or `cabal v2-repl` or similar.
     ///
+    /// This is used to launch the underlying `ghci` session that `ghcid-ng` controls.
+    ///
     /// May contain quoted arguments which will be parsed in a `sh`-like manner.
-    #[arg(long)]
+    #[arg(long, value_name = "SHELL_COMMAND")]
     pub command: Option<String>,
 
     /// A `ghci` command which runs tests, like `TestMain.testMain`. If given, this command will be
     /// run after reloads.
-    #[arg(long)]
-    pub test: Option<String>,
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub test_ghci: Option<String>,
+
+    /// Shell commands to run before starting or restarting `ghci`.
+    ///
+    /// This can be used to regenerate `.cabal` files with `hpack`.
+    #[arg(long, value_name = "SHELL_COMMAND")]
+    pub before_startup_shell: Vec<String>,
 
     /// `ghci` commands to run on startup. Use `:set args ...` in combination with `--test` to set
     /// the command-line arguments for tests.
-    #[arg(long)]
-    pub setup: Vec<String>,
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub after_startup_ghci: Vec<String>,
 
     /// A file to write compilation errors to. This is analogous to `ghcid.txt`.
     #[arg(long)]

--- a/ghcid-ng/src/command.rs
+++ b/ghcid-ng/src/command.rs
@@ -129,6 +129,22 @@ impl Default for ClonableCommand {
 }
 
 impl ClonableCommand {
+    /// Create a new [`ClonableCommand`] from the given program name.
+    ///
+    /// See [`StdCommand::new`].
+    pub fn new(program: impl Into<OsString>) -> Self {
+        Self {
+            program: program.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Add an argument to this command. See [`StdCommand::arg`].
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
     /// Create a new [`std::process::Command`] from this command's configuration.
     pub fn as_std(&self) -> StdCommand {
         let mut ret = StdCommand::new(&self.program);

--- a/ghcid-ng/src/command.rs
+++ b/ghcid-ng/src/command.rs
@@ -1,12 +1,17 @@
 //! Shell commands: parsing, formatting, signalling, and so on.
 
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command as StdCommand;
+use std::process::Stdio;
+
 use miette::miette;
 use miette::IntoDiagnostic;
 use miette::WrapErr;
 use nix::sys::signal;
 use nix::sys::signal::Signal;
 use nix::unistd::Pid;
-use tap::Tap;
 use tokio::process::Child;
 use tokio::process::Command;
 
@@ -23,17 +28,22 @@ pub fn format(command: &Command) -> String {
 }
 
 /// Construct a [`Command`] by parsing a string of shell-quoted arguments.
-pub fn from_string(shell_command: &str) -> miette::Result<Command> {
+pub fn from_string(shell_command: &str) -> miette::Result<ClonableCommand> {
     let tokens = shell_words::split(shell_command)
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to split shell command: {shell_command:?}"))?;
 
     match &*tokens {
         [] => Err(miette!("Command has no program: {shell_command:?}")),
-        [program] => Ok(Command::new(program)),
-        [program, args @ ..] => Ok(Command::new(program).tap_mut(|cmd| {
-            cmd.args(args);
-        })),
+        [program] => Ok(ClonableCommand {
+            program: program.into(),
+            ..Default::default()
+        }),
+        [program, args @ ..] => Ok(ClonableCommand {
+            program: program.into(),
+            args: args.iter().map(Into::into).collect(),
+            ..Default::default()
+        }),
     }
 }
 
@@ -56,4 +66,110 @@ pub fn send_signal(child: &Child, signal: Signal) -> miette::Result<()> {
 /// Partially-applied form of [`send_signal`].
 pub fn send_sigterm(child: &Child) -> miette::Result<()> {
     send_signal(child, Signal::SIGTERM)
+}
+
+/// Like [`std::process::Stdio`], but it implements [`Clone`].
+///
+/// Unlike [`Stdio`], this value can't represent arbitrary files or file descriptors.
+#[derive(Debug, Clone, Copy)]
+pub enum ClonableStdio {
+    /// The stream will be ignored. Equivalent to attaching the stream to `/dev/null`.
+    Null,
+    /// The child will inherit from the corresponding parent descriptor.
+    Inherit,
+    /// A new pipe should be arranged to connect the parent and child processes.
+    Piped,
+}
+
+impl From<ClonableStdio> for Stdio {
+    fn from(value: ClonableStdio) -> Self {
+        match value {
+            ClonableStdio::Null => Self::null(),
+            ClonableStdio::Inherit => Self::inherit(),
+            ClonableStdio::Piped => Self::piped(),
+        }
+    }
+}
+
+impl ClonableStdio {
+    /// Convert this value into a [`Stdio`].
+    pub fn as_std(&self) -> Stdio {
+        match self {
+            ClonableStdio::Null => Stdio::null(),
+            ClonableStdio::Inherit => Stdio::inherit(),
+            ClonableStdio::Piped => Stdio::piped(),
+        }
+    }
+}
+
+/// Like [`std::process::Command`], but it implements [`Clone`].
+#[derive(Debug, Clone)]
+pub struct ClonableCommand {
+    program: OsString,
+    args: Vec<OsString>,
+    current_dir: Option<PathBuf>,
+    stdin: Option<ClonableStdio>,
+    stdout: Option<ClonableStdio>,
+    stderr: Option<ClonableStdio>,
+    env: Option<HashMap<OsString, Option<OsString>>>,
+}
+
+impl Default for ClonableCommand {
+    fn default() -> Self {
+        Self {
+            program: Default::default(),
+            args: Default::default(),
+            current_dir: Default::default(),
+            stdin: Default::default(),
+            stdout: Default::default(),
+            stderr: Default::default(),
+            env: Some(Default::default()),
+        }
+    }
+}
+
+impl ClonableCommand {
+    /// Create a new [`std::process::Command`] from this command's configuration.
+    pub fn as_std(&self) -> StdCommand {
+        let mut ret = StdCommand::new(&self.program);
+
+        ret.args(&self.args);
+        if let Some(current_dir) = self.current_dir.as_deref() {
+            ret.current_dir(current_dir);
+        }
+        if let Some(stdin) = self.stdin {
+            ret.stdin(stdin.as_std());
+        }
+        if let Some(stdout) = self.stdout {
+            ret.stdout(stdout.as_std());
+        }
+        if let Some(stderr) = self.stderr {
+            ret.stderr(stderr.as_std());
+        }
+
+        match &self.env {
+            None => {
+                ret.env_clear();
+            }
+            Some(env) => {
+                for (name, value) in env {
+                    match value {
+                        None => {
+                            ret.env_remove(name);
+                        }
+                        Some(value) => {
+                            ret.env(name, value);
+                        }
+                    }
+                }
+            }
+        }
+
+        ret
+    }
+
+    /// Create a new [`Command`] from this command's configuration.
+    pub fn as_tokio(&self) -> Command {
+        self.as_std().into()
+    }
 }

--- a/ghcid-ng/src/command.rs
+++ b/ghcid-ng/src/command.rs
@@ -81,8 +81,8 @@ pub enum ClonableStdio {
     Piped,
 }
 
-impl From<ClonableStdio> for Stdio {
-    fn from(value: ClonableStdio) -> Self {
+impl From<&ClonableStdio> for Stdio {
+    fn from(value: &ClonableStdio) -> Self {
         match value {
             ClonableStdio::Null => Self::null(),
             ClonableStdio::Inherit => Self::inherit(),
@@ -91,14 +91,16 @@ impl From<ClonableStdio> for Stdio {
     }
 }
 
+impl From<ClonableStdio> for Stdio {
+    fn from(value: ClonableStdio) -> Self {
+        (&value).into()
+    }
+}
+
 impl ClonableStdio {
     /// Convert this value into a [`Stdio`].
     pub fn as_std(&self) -> Stdio {
-        match self {
-            ClonableStdio::Null => Stdio::null(),
-            ClonableStdio::Inherit => Stdio::inherit(),
-            ClonableStdio::Piped => Stdio::piped(),
-        }
+        self.into()
     }
 }
 

--- a/ghcid-ng/src/ghci/mod.rs
+++ b/ghcid-ng/src/ghci/mod.rs
@@ -58,7 +58,7 @@ pub const IO_MODULE_NAME: &str = "GHCID_NG_IO_INTERNAL__";
 /// could consider making this struct borrowed.
 #[derive(Debug, Clone)]
 pub struct GhciOpts {
-    /// The command used to start the underyling `ghci` session.
+    /// The command used to start the underlying `ghci` session.
     pub command: ClonableCommand,
     /// A path to write `ghci` errors to.
     pub error_path: Option<Utf8PathBuf>,

--- a/ghcid-ng/src/ghci/mod.rs
+++ b/ghcid-ng/src/ghci/mod.rs
@@ -50,7 +50,7 @@ pub const PROMPT: &str = "###~GHCID-NG-PROMPT~###";
 /// `GHCID_NG_IO_INTERNAL__` that's on you.
 pub const IO_MODULE_NAME: &str = "GHCID_NG_IO_INTERNAL__";
 
-/// Options for constructing a [`Ghci`]. This is like a lazier builder interface, mostly provided
+/// Options for constructing a [`Ghci`]. This is like a lower-effort builder interface, mostly provided
 /// because Rust tragically lacks named arguments.
 ///
 /// Some of the other `*Opts` structs include borrowed data from the [`Opts`] struct, but this one

--- a/ghcid-ng/src/ghci/mod.rs
+++ b/ghcid-ng/src/ghci/mod.rs
@@ -35,7 +35,6 @@ use show_modules::ModuleSet;
 use crate::aho_corasick::AhoCorasickExt;
 use crate::buffers::LINE_BUFFER_CAPACITY;
 use crate::cli::Opts;
-use crate::command;
 use crate::command::ClonableCommand;
 use crate::event_filter::FileEvent;
 use crate::incremental_reader::IncrementalReader;
@@ -63,8 +62,6 @@ pub struct GhciOpts {
     pub command: ClonableCommand,
     /// A path to write `ghci` errors to.
     pub error_path: Option<Utf8PathBuf>,
-    /// Shell commands to run before starting or restarting `ghci`.
-    pub before_startup_shell: Vec<String>,
     /// `ghci` commands to run after starting or restarting `ghci`.
     pub after_startup_ghci: Vec<String>,
     /// `ghci` command which runs tests.
@@ -79,8 +76,10 @@ impl GhciOpts {
     pub fn from_cli(opts: &Opts) -> miette::Result<Self> {
         // TODO: implement fancier default command
         // See: https://github.com/ndmitchell/ghcid/blob/e2852979aa644c8fed92d46ab529d2c6c1c62b59/src/Ghcid.hs#L142-L171
-        let command = command::from_string(opts.command.as_deref().unwrap_or("cabal repl"))
-            .wrap_err("Failed to split `--command` value into arguments")?;
+        let command = opts
+            .command
+            .clone()
+            .unwrap_or_else(|| ClonableCommand::new("cabal").arg("repl"));
 
         Ok(Self {
             command,

--- a/ghcid-ng/src/ghci/stdin.rs
+++ b/ghcid-ng/src/ghci/stdin.rs
@@ -48,7 +48,7 @@ impl GhciStdin {
     pub async fn initialize(
         &mut self,
         stdout: &mut GhciStdout,
-        setup_commands: Vec<String>,
+        setup_commands: &[String],
     ) -> miette::Result<()> {
         self.set_mode(stdout, Mode::Internal).await?;
         self.write_line(stdout, &format!(":set prompt {PROMPT}\n"))

--- a/ghcid-ng/src/main.rs
+++ b/ghcid-ng/src/main.rs
@@ -19,11 +19,7 @@ use tap::Tap;
 async fn main() -> miette::Result<()> {
     miette::set_panic_hook();
     let opts = cli::Opts::parse().tap_mut(|opts| opts.init());
-    tracing::install_tracing(
-        &opts.logging.tracing_filter,
-        &opts.logging.trace_spans,
-        opts.logging.log_json.as_deref(),
-    )?;
+    tracing::TracingOpts::from_cli(&opts).install()?;
 
     ::tracing::warn!(
         "This is a prerelease alpha version of `ghcid-ng`! Expect a rough user experience, and please report bugs or other issues to the #mighty-dux channel on Slack."

--- a/ghcid-ng/src/main.rs
+++ b/ghcid-ng/src/main.rs
@@ -4,18 +4,15 @@
 //! `ghcid-ng` watches your modules for changes and reloads them in a `ghci` session, displaying
 //! any errors.
 
-use std::sync::Arc;
-
 use clap::Parser;
 use ghcid_ng::cli;
-use ghcid_ng::command;
 use ghcid_ng::ghci::Ghci;
+use ghcid_ng::ghci::GhciOpts;
 use ghcid_ng::tracing;
 use ghcid_ng::watcher::Watcher;
 use miette::IntoDiagnostic;
 use miette::WrapErr;
 use tap::Tap;
-use tokio::sync::Mutex;
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
@@ -31,14 +28,7 @@ async fn main() -> miette::Result<()> {
         "This is a prerelease alpha version of `ghcid-ng`! Expect a rough user experience, and please report bugs or other issues to the #mighty-dux channel on Slack."
     );
 
-    // TODO: implement fancier default command
-    // See: https://github.com/ndmitchell/ghcid/blob/e2852979aa644c8fed92d46ab529d2c6c1c62b59/src/Ghcid.hs#L142-L171
-    let ghci_command = Arc::new(Mutex::new(
-        command::from_string(opts.command.as_deref().unwrap_or("cabal repl"))
-            .wrap_err("Failed to split `--command` value into arguments")?,
-    ));
-
-    let ghci = Ghci::new(ghci_command, opts.errors.clone(), opts.setup, opts.test)
+    let ghci = Ghci::new(GhciOpts::from_cli(&opts)?)
         .await
         .wrap_err("Failed to start `ghci`")?;
     let watcher = Watcher::new(

--- a/ghcid-ng/src/main.rs
+++ b/ghcid-ng/src/main.rs
@@ -10,6 +10,7 @@ use ghcid_ng::ghci::Ghci;
 use ghcid_ng::ghci::GhciOpts;
 use ghcid_ng::tracing;
 use ghcid_ng::watcher::Watcher;
+use ghcid_ng::watcher::WatcherOpts;
 use miette::IntoDiagnostic;
 use miette::WrapErr;
 use tap::Tap;
@@ -31,13 +32,8 @@ async fn main() -> miette::Result<()> {
     let ghci = Ghci::new(GhciOpts::from_cli(&opts)?)
         .await
         .wrap_err("Failed to start `ghci`")?;
-    let watcher = Watcher::new(
-        ghci,
-        &opts.watch.paths,
-        opts.watch.debounce,
-        opts.watch.poll,
-    )
-    .wrap_err("Failed to start file watcher")?;
+    let watcher = Watcher::new(ghci, WatcherOpts::from_cli(&opts))
+        .wrap_err("Failed to start file watcher")?;
 
     watcher
         .handle

--- a/ghcid-ng/src/tracing/mod.rs
+++ b/ghcid-ng/src/tracing/mod.rs
@@ -11,41 +11,63 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
 
+use crate::cli::Opts;
+
 mod format;
 
-/// Initialize the logging framework.
-pub fn install_tracing(
-    filter_directives: &str,
-    trace_spans: &[FmtSpan],
-    json_log_path: Option<&Utf8Path>,
-) -> miette::Result<()> {
-    let env_filter = EnvFilter::try_new(filter_directives).into_diagnostic()?;
+/// Options for initializing the [`tracing`] logging framework. This is like a lower-effort builder
+/// interface, mostly provided because Rust tragically lacks named arguments.
+pub struct TracingOpts<'opts> {
+    /// Filter directives to control which events are logged.
+    pub filter_directives: &'opts str,
+    /// Control which span events are logged.
+    pub trace_spans: &'opts [FmtSpan],
+    /// If given, log as JSON to the given path.
+    pub json_log_path: Option<&'opts Utf8Path>,
+}
 
-    let fmt_span = trace_spans
-        .iter()
-        .fold(FmtSpan::NONE, |result, item| result | item.clone());
-
-    let fmt_layer = fmt::layer()
-        .with_span_events(fmt_span.clone())
-        .fmt_fields(format::SpanFieldFormatter::default())
-        .event_format(format::EventFormatter::default())
-        .with_filter(env_filter);
-
-    let registry = tracing_subscriber::registry();
-
-    let registry = registry.with(fmt_layer);
-
-    match json_log_path {
-        Some(path) => {
-            let json_layer = tracing_json_layer(filter_directives, path, fmt_span)?;
-            registry.with(json_layer).init();
-        }
-        None => {
-            registry.init();
+impl<'opts> TracingOpts<'opts> {
+    /// Construct options for initializing the [`tracing`] logging framework from parsed
+    /// commmand-line interface arguments as [`Opts`].
+    pub fn from_cli(opts: &'opts Opts) -> Self {
+        Self {
+            filter_directives: &opts.logging.tracing_filter,
+            trace_spans: &opts.logging.trace_spans,
+            json_log_path: opts.logging.log_json.as_deref(),
         }
     }
 
-    Ok(())
+    /// Initialize the [`tracing`] logging framework.
+    pub fn install(&self) -> miette::Result<()> {
+        let env_filter = EnvFilter::try_new(self.filter_directives).into_diagnostic()?;
+
+        let fmt_span = self
+            .trace_spans
+            .iter()
+            .fold(FmtSpan::NONE, |result, item| result | item.clone());
+
+        let fmt_layer = fmt::layer()
+            .with_span_events(fmt_span.clone())
+            .fmt_fields(format::SpanFieldFormatter::default())
+            .event_format(format::EventFormatter::default())
+            .with_filter(env_filter);
+
+        let registry = tracing_subscriber::registry();
+
+        let registry = registry.with(fmt_layer);
+
+        match &self.json_log_path {
+            Some(path) => {
+                let json_layer = tracing_json_layer(self.filter_directives, path, fmt_span)?;
+                registry.with(json_layer).init();
+            }
+            None => {
+                registry.init();
+            }
+        }
+
+        Ok(())
+    }
 }
 
 fn tracing_json_layer<S>(

--- a/ghcid-ng/tests/test.rs
+++ b/ghcid-ng/tests/test.rs
@@ -10,7 +10,7 @@ async fn can_run_test_suite_on_reload() {
     let error_path = "ghcid.txt";
     let mut session = GhcidNg::new_with_args(
         "tests/data/simple",
-        ["--test", "TestMain.main", "--errors", error_path],
+        ["--test-ghci", "TestMain.main", "--errors", error_path],
     )
     .await
     .expect("ghcid-ng starts");


### PR DESCRIPTION
This parses shell command arguments into a new `ClonableCommand` struct, which stores the program, arguments, and environment for a command to be run.

I've also converted several of the more complex constructors into accepting structs instead of multiple positional arguments, which get challenging to track.
