### PR TITLE
Add before-start hook to the test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ version = "0.1.0"
 dependencies = [
  "backoff",
  "fs_extra",
+ "futures-util",
  "itertools",
  "miette",
  "nix",

--- a/ghcid-ng/tests/error_log.rs
+++ b/ghcid-ng/tests/error_log.rs
@@ -4,14 +4,16 @@ use indoc::indoc;
 use test_harness::fs;
 use test_harness::test;
 use test_harness::GhcVersion::*;
-use test_harness::GhcidNg;
+use test_harness::GhcidNgBuilder;
 use test_harness::Matcher;
 
 /// Test that `ghcid-ng --errors ...` can write the error log.
 #[test]
 async fn can_write_error_log() {
     let error_path = "ghcid.txt";
-    let mut session = GhcidNg::new_with_args("tests/data/simple", ["--errors", error_path])
+    let mut session = GhcidNgBuilder::new("tests/data/simple")
+        .with_args(["--errors", error_path])
+        .start()
         .await
         .expect("ghcid-ng starts");
     let error_path = session.path(error_path);
@@ -36,7 +38,9 @@ async fn can_write_error_log() {
 #[test]
 async fn can_write_error_log_compilation_errors() {
     let error_path = "ghcid.txt";
-    let mut session = GhcidNg::new_with_args("tests/data/simple", ["--errors", error_path])
+    let mut session = GhcidNgBuilder::new("tests/data/simple")
+        .with_args(["--errors", error_path])
+        .start()
         .await
         .expect("ghcid-ng starts");
     let error_path = session.path(error_path);

--- a/ghcid-ng/tests/test.rs
+++ b/ghcid-ng/tests/test.rs
@@ -1,19 +1,18 @@
 use expect_test::expect;
 use test_harness::fs;
 use test_harness::test;
-use test_harness::GhcidNg;
+use test_harness::GhcidNgBuilder;
 use test_harness::Matcher;
 
 /// Test that `ghcid-ng --test ...` can run a test suite.
 #[test]
 async fn can_run_test_suite_on_reload() {
     let error_path = "ghcid.txt";
-    let mut session = GhcidNg::new_with_args(
-        "tests/data/simple",
-        ["--test-ghci", "TestMain.testMain", "--errors", error_path],
-    )
-    .await
-    .expect("ghcid-ng starts");
+    let mut session = GhcidNgBuilder::new("tests/data/simple")
+        .with_args(["--test-ghci", "TestMain.testMain", "--errors", error_path])
+        .start()
+        .await
+        .expect("ghcid-ng starts");
     let error_path = session.path(error_path);
     session
         .wait_until_ready()

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -8,9 +8,10 @@ publish = false
 [dependencies]
 backoff = { version = "0.4.0", default-features = false }
 fs_extra = "1.3.0"
+futures-util = "0.3.28"
 itertools = "0.11.0"
 miette = { version = "5.9.0", features = ["fancy"] }
-nix = { version = "0.26.2", default_features = false, features = ["process"] }
+nix = { version = "0.26.2", default_features = false, features = ["process", "signal"] }
 regex = "1.9.4"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = "1.0.105"

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -119,7 +119,7 @@ impl GhcidNg {
             .args([
                 "--command",
                 &format!(
-                    "cabal --offline --with-compiler=ghc-{full_ghc_version} -flocal-dev v2-repl lib:test-dev"
+                    "cabal --offline --with-compiler=ghc-{full_ghc_version} -flocal-dev --repl-option -fdiagnostics-color=always v2-repl lib:test-dev"
                 ),
                 "--before-startup-shell",
                 "hpack --force .",

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -214,7 +214,7 @@ impl GhcidNg {
             Ok(Ok(event)) => Ok(event),
             Ok(Err(err)) => Err(err),
             Err(_) => Err(miette!(
-                "Waiting for a log message timed out after {timeout_duration:.2?}"
+                "Waiting for a log message matching {matcher} timed out after {timeout_duration:.2?}"
             )),
         }
     }

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -19,6 +19,7 @@ pub use test_harness_macro::test;
 
 mod ghcid_ng;
 pub use ghcid_ng::GhcidNg;
+pub use ghcid_ng::GhcidNgBuilder;
 
 mod ghc_version;
 pub use ghc_version::GhcVersion;

--- a/test-harness/src/matcher.rs
+++ b/test-harness/src/matcher.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
+use std::fmt::Display;
 
+use itertools::Itertools;
 use regex::Regex;
 use serde_json::Value;
 
@@ -150,6 +152,33 @@ impl Matcher {
         }
 
         true
+    }
+}
+
+impl Display for Matcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.message.as_str())?;
+
+        if let Some(target) = &self.target {
+            write!(f, " in module {target}")?;
+        }
+
+        if !self.spans.is_empty() {
+            write!(f, " in spans {}", self.spans.join(", "))?;
+        }
+
+        if !self.fields.is_empty() {
+            write!(
+                f,
+                " with fields {}",
+                self.fields
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v:?}"))
+                    .join(", ")
+            )?;
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This lets tests run code to modify the project before starting `ghcid-ng`.

The before-start hook is implemented in terms of a new `GhcidNgBuilder` interface.