### PR TITLE
Make `IncrementalReader` return strings, not lists of lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "humantime",
  "indoc",
  "itertools",
+ "line-span",
  "miette",
  "nix",
  "once_cell",
@@ -1001,6 +1002,12 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "line-span"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fc123b2f6600099ca18248f69e3ee02b09c4188c0d98e9a690d90dec3e408a"
 
 [[package]]
 name = "linux-raw-sys"

--- a/ghcid-ng/Cargo.toml
+++ b/ghcid-ng/Cargo.toml
@@ -22,6 +22,7 @@ camino = "1.1.4"
 clap = { version = "4.3.2", features = ["derive", "wrap_help", "env"] }
 humantime = "2.1.0"
 itertools = "0.11.0"
+line-span = "0.1.5"
 miette = { version = "5.9.0", features = ["fancy"] }
 nix = { version = "0.26.2", default_features = false, features = ["process"] }
 once_cell = "1.18.0"

--- a/ghcid-ng/src/ghci/parse/module_set.rs
+++ b/ghcid-ng/src/ghci/parse/module_set.rs
@@ -49,7 +49,6 @@ impl ModuleSet {
     /// Determine if a module with the given source path is contained in this module set.
     ///
     /// Returns `Err` if the `path` cannot be canonicalized.
-    #[allow(dead_code)]
     pub fn contains_source_path(&self, path: &Utf8Path) -> miette::Result<bool> {
         Ok(self.set.contains(&canonicalize(path)?))
     }


### PR DESCRIPTION
This is conceptually somewhat simpler and also gives us output that's easier to feed to parsers.