### PR TITLE
Fix "module defined in multiple files" by parsing GHC diagnostics

### DIFF
--- a/ghcid-ng/src/ghci/mod.rs
+++ b/ghcid-ng/src/ghci/mod.rs
@@ -400,19 +400,15 @@ impl Ghci {
         &mut self,
         path: &Utf8Path,
     ) -> miette::Result<Option<CompilationResult>> {
-        let messages = self.stdin.add_module(&mut self.stdout, &path).await?;
+        let messages = self.stdin.add_module(&mut self.stdout, path).await?;
 
         let result = self.process_ghc_messages(messages).await?;
 
-        match result {
-            Some(CompilationResult::Ok) => {
-                self.modules.insert_source_path(&path)?;
-            }
-            _ => {
-                // Compilation failed or otherwise didn't print a summary, so we don't want to add
-                // the module to the module set.
-            }
+        if let Some(CompilationResult::Ok) = result {
+            self.modules.insert_source_path(path)?;
         }
+        // Otherwise, compilation failed or otherwise didn't print a summary, so we don't want to
+        // add the module to the module set.
 
         Ok(result)
     }

--- a/ghcid-ng/src/ghci/mod.rs
+++ b/ghcid-ng/src/ghci/mod.rs
@@ -205,6 +205,7 @@ impl Ghci {
                     (Mode::Compiling, String::with_capacity(LINE_BUFFER_CAPACITY)),
                     (Mode::Testing, String::with_capacity(LINE_BUFFER_CAPACITY)),
                 ]),
+                buffer: String::with_capacity(LINE_BUFFER_CAPACITY),
                 error_path: ret.opts.error_path.clone(),
                 mode: Mode::Compiling,
                 has_unwritten_data: false,

--- a/ghcid-ng/src/ghci/mod.rs
+++ b/ghcid-ng/src/ghci/mod.rs
@@ -475,6 +475,16 @@ impl Ghci {
             }
         }
 
+        // Tell the stderr stream to write the error log and then finish.
+        {
+            let (sender, receiver) = oneshot::channel();
+            self.stderr
+                .send(StderrEvent::Write(sender))
+                .await
+                .into_diagnostic()?;
+            receiver.await.into_diagnostic()?;
+        }
+
         Ok(None)
     }
 }

--- a/ghcid-ng/src/ghci/parse/ghc_message/cant_find_file_diagnostic.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/cant_find_file_diagnostic.rs
@@ -1,0 +1,65 @@
+use camino::Utf8PathBuf;
+use winnow::ascii::space1;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::ghci::parse::lines::until_newline;
+
+use crate::ghci::parse::ghc_message::position;
+use crate::ghci::parse::ghc_message::severity;
+use crate::ghci::parse::ghc_message::GhcMessage;
+
+/// Parse a "can't find file" message like this:
+///
+/// ```plain
+/// <no location info>: error: can't find file: Why.hs
+/// ```
+pub fn cant_find_file_diagnostic(input: &mut &str) -> PResult<GhcMessage> {
+    let _ = position::parse_unhelpful_position.parse_next(input)?;
+    let _ = space1.parse_next(input)?;
+    let severity = severity::parse_severity_colon.parse_next(input)?;
+    let _ = space1.parse_next(input)?;
+    let _ = "can't find file: ".parse_next(input)?;
+    let path = until_newline.parse_next(input)?;
+
+    Ok(GhcMessage::Diagnostic {
+        severity,
+        path: Some(Utf8PathBuf::from(path)),
+        span: Default::default(),
+        message: "can't find file".to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use severity::Severity;
+
+    #[test]
+    fn test_parse_cant_find_file_message() {
+        assert_eq!(
+            cant_find_file_diagnostic
+                .parse("<no location info>: error: can't find file: Why.hs\n")
+                .unwrap(),
+            GhcMessage::Diagnostic {
+                severity: Severity::Error,
+                path: Some("Why.hs".into()),
+                span: Default::default(),
+                message: "can't find file".to_owned()
+            }
+        );
+
+        // Doesn't parse another error message.
+        assert!(cant_find_file_diagnostic
+            .parse(indoc!(
+                "
+                <no location info>: error: can't find file: Why.hs
+                Error: Uh oh!
+                "
+            ))
+            .is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/compilation_summary.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/compilation_summary.rs
@@ -1,0 +1,135 @@
+use winnow::ascii::digit1;
+use winnow::ascii::line_ending;
+use winnow::combinator::alt;
+use winnow::combinator::opt;
+use winnow::combinator::terminated;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::ghci::parse::CompilationResult;
+
+use super::GhcMessage;
+
+/// Parse a compilation summary, like `Ok, one module loaded.`.
+pub fn compilation_summary(input: &mut &str) -> PResult<GhcMessage> {
+    fn inner(input: &mut &str) -> PResult<CompilationResult> {
+        let compilation_result = alt((
+            "Ok".map(|_| CompilationResult::Ok),
+            "Failed".map(|_| CompilationResult::Err),
+        ))
+        .parse_next(input)?;
+        let _ = ", ".parse_next(input)?;
+
+        // There's special cases for 0-6 modules!
+        // https://gitlab.haskell.org/ghc/ghc/-/blob/288235bbe5a59b8a1bda80aaacd59e5717417726/ghc/GHCi/UI.hs#L2286-L2287
+        // https://gitlab.haskell.org/ghc/ghc/-/blob/288235bbe5a59b8a1bda80aaacd59e5717417726/compiler/GHC/Utils/Outputable.hs#L1429-L1453
+        let _ =
+            alt((digit1, "no", "one", "two", "three", "four", "five", "six")).parse_next(input)?;
+        let _ = " module".parse_next(input)?;
+        let _ = opt("s").parse_next(input)?;
+        let _ = " loaded.".parse_next(input)?;
+        Ok(compilation_result)
+    }
+
+    terminated(inner.with_recognized(), line_ending)
+        .map(|(result, message)| GhcMessage::Summary {
+            result,
+            message: message.to_owned(),
+        })
+        .parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_compilation_summary_message() {
+        assert_eq!(
+            compilation_summary
+                .parse("Ok, 123 modules loaded.\n")
+                .unwrap(),
+            GhcMessage::Summary {
+                result: CompilationResult::Ok,
+                message: "Ok, 123 modules loaded.".into()
+            }
+        );
+
+        assert_eq!(
+            compilation_summary
+                .parse("Ok, no modules loaded.\n")
+                .unwrap(),
+            GhcMessage::Summary {
+                result: CompilationResult::Ok,
+                message: "Ok, no modules loaded.".into()
+            }
+        );
+
+        assert_eq!(
+            compilation_summary
+                .parse("Ok, one module loaded.\n")
+                .unwrap(),
+            GhcMessage::Summary {
+                result: CompilationResult::Ok,
+                message: "Ok, one module loaded.".into()
+            }
+        );
+
+        assert_eq!(
+            compilation_summary
+                .parse("Ok, six modules loaded.\n")
+                .unwrap(),
+            GhcMessage::Summary {
+                result: CompilationResult::Ok,
+                message: "Ok, six modules loaded.".into()
+            }
+        );
+
+        assert_eq!(
+            compilation_summary
+                .parse("Failed, 7 modules loaded.\n")
+                .unwrap(),
+            GhcMessage::Summary {
+                result: CompilationResult::Err,
+                message: "Failed, 7 modules loaded.".into()
+            }
+        );
+
+        assert_eq!(
+            compilation_summary
+                .parse("Failed, one module loaded.\n")
+                .unwrap(),
+            GhcMessage::Summary {
+                result: CompilationResult::Err,
+                message: "Failed, one module loaded.".into()
+            }
+        );
+
+        // Negative cases
+        // Whitespace.
+        assert!(compilation_summary
+            .parse("Ok, 10 modules loaded.\n ")
+            .is_err());
+        assert!(compilation_summary
+            .parse(" Ok, 10 modules loaded.\n")
+            .is_err());
+        assert!(compilation_summary
+            .parse("Ok, 10 modules loaded.\n\n")
+            .is_err());
+        // Two messages
+        assert!(compilation_summary
+            .parse(indoc!(
+                "
+                Ok, 10 modules loaded.
+                Ok, 10 modules loaded.
+                "
+            ))
+            .is_err());
+        assert!(compilation_summary
+            .parse("Weird, no modules loaded.\n")
+            .is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/compiling.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/compiling.rs
@@ -1,0 +1,88 @@
+use winnow::ascii::digit1;
+use winnow::ascii::space0;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::ghci::parse::lines::rest_of_line;
+use crate::ghci::parse::module_and_files;
+
+use super::GhcMessage;
+
+/// Parse a `[1 of 3] Compiling Foo ( Foo.hs, Foo.o, interpreted )` message.
+pub fn compiling(input: &mut &str) -> PResult<GhcMessage> {
+    let _ = "[".parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let _ = digit1.parse_next(input)?;
+    let _ = " of ".parse_next(input)?;
+    let _ = digit1.parse_next(input)?;
+    let _ = "]".parse_next(input)?;
+    let _ = " Compiling ".parse_next(input)?;
+    let module = module_and_files.parse_next(input)?;
+    let _ = rest_of_line.parse_next(input)?;
+
+    Ok(GhcMessage::Compiling(module))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use module_and_files::Module;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_compiling_message() {
+        assert_eq!(
+            compiling
+                .parse("[1 of 3] Compiling Foo ( Foo.hs, Foo.o, interpreted )\n")
+                .unwrap(),
+            GhcMessage::Compiling(Module {
+                name: "Foo".into(),
+                path: "Foo.hs".into()
+            })
+        );
+
+        assert_eq!(
+            compiling
+                .parse("[   1 of 6508] \
+                    Compiling A.DoggyPrelude.Puppy \
+                    ( src/A/DoggyPrelude/Puppy.hs, \
+                      /Users/wiggles/doggy-web-backend6/dist-newstyle/build/aarch64-osx/ghc-9.6.2/doggy-web-backend-0/l/test-dev/noopt/build/test-dev/A/DoggyPrelude/Puppy.dyn_o \
+                      ) [Doggy.Lint package changed]\n")
+                .unwrap(),
+            GhcMessage::Compiling(Module{
+                name: "A.DoggyPrelude.Puppy".into(),
+                path: "src/A/DoggyPrelude/Puppy.hs".into()
+            })
+        );
+
+        assert_eq!(
+            compiling
+                .parse("[1 of 4] Compiling MyLib            ( src/MyLib.hs )\n")
+                .unwrap(),
+            GhcMessage::Compiling(Module {
+                name: "MyLib".into(),
+                path: "src/MyLib.hs".into()
+            })
+        );
+
+        // Shouldn't parse multiple lines.
+        assert!(compiling
+            .parse(indoc!(
+                "
+                [1 of 4] Compiling MyLib            ( src/MyLib.hs )
+                [1 of 4] Compiling MyLib            ( src/MyLib.hs, interpreted )
+                "
+            ))
+            .is_err());
+        assert!(compiling
+            .parse(indoc!(
+                "
+                [1 of 4] Compiling MyLib            ( src/MyLib.hs )
+                [1 of 4] Compiling MyLib            ( src/MyLib.hs )
+                "
+            ))
+            .is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/generic_diagnostic.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/generic_diagnostic.rs
@@ -1,0 +1,102 @@
+use winnow::ascii::space0;
+use winnow::ascii::space1;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::ghci::parse::ghc_message::message_body::parse_message_body;
+use crate::ghci::parse::ghc_message::path_colon;
+use crate::ghci::parse::ghc_message::position;
+use crate::ghci::parse::ghc_message::severity;
+use crate::ghci::parse::ghc_message::GhcMessage;
+
+/// Parse a warning or error like this:
+///
+/// ```plain
+/// NotStockDeriveable.hs:6:12: error: [GHC-00158]
+///     • Can't make a derived instance of ‘MyClass MyType’:
+///         ‘MyClass’ is not a stock derivable class (Eq, Show, etc.)
+///     • In the data declaration for ‘MyType’
+///     Suggested fix: Perhaps you intended to use DeriveAnyClass
+///   |
+/// 6 |   deriving MyClass
+///   |            ^^^^^^^
+/// ```
+pub fn generic_diagnostic(input: &mut &str) -> PResult<GhcMessage> {
+    // TODO: Confirm that the input doesn't start with space?
+    let path = path_colon.parse_next(input)?;
+    let span = position::parse_position_range.parse_next(input)?;
+    let _ = space1.parse_next(input)?;
+    let severity = severity::parse_severity_colon.parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let message = parse_message_body.parse_next(input)?;
+
+    Ok(GhcMessage::Diagnostic {
+        severity,
+        path: Some(path.to_owned()),
+        span,
+        message: message.to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use position::PositionRange;
+    use pretty_assertions::assert_eq;
+    use severity::Severity;
+
+    #[test]
+    fn test_parse_diagnostic_message() {
+        assert_eq!(
+            generic_diagnostic
+                .parse(indoc!(
+                    "NotStockDeriveable.hs:6:12: error: [GHC-00158]
+                        • Can't make a derived instance of ‘MyClass MyType’:
+                            ‘MyClass’ is not a stock derivable class (Eq, Show, etc.)
+                        • In the data declaration for ‘MyType’
+                        Suggested fix: Perhaps you intended to use DeriveAnyClass
+                      |
+                    6 |   deriving MyClass
+                      |            ^^^^^^^
+                    "
+                ))
+                .unwrap(),
+            GhcMessage::Diagnostic {
+                severity: Severity::Error,
+                path: Some("NotStockDeriveable.hs".into()),
+                span: PositionRange::new(6, 12, 6, 12),
+                message: indoc!(
+                    "[GHC-00158]
+                        • Can't make a derived instance of ‘MyClass MyType’:
+                            ‘MyClass’ is not a stock derivable class (Eq, Show, etc.)
+                        • In the data declaration for ‘MyType’
+                        Suggested fix: Perhaps you intended to use DeriveAnyClass
+                      |
+                    6 |   deriving MyClass
+                      |            ^^^^^^^
+                    "
+                )
+                .into()
+            }
+        );
+
+        // Doesn't parse another error message.
+        assert!(generic_diagnostic
+            .parse(indoc!(
+                "NotStockDeriveable.hs:6:12: error: [GHC-00158]
+                        • Can't make a derived instance of ‘MyClass MyType’:
+                            ‘MyClass’ is not a stock derivable class (Eq, Show, etc.)
+                        • In the data declaration for ‘MyType’
+                        Suggested fix: Perhaps you intended to use DeriveAnyClass
+                      |
+                    6 |   deriving MyClass
+                      |            ^^^^^^^
+
+                    Error: Uh oh!
+                    "
+            ))
+            .is_err(),);
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/loaded_configuration.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/loaded_configuration.rs
@@ -1,0 +1,47 @@
+use camino::Utf8PathBuf;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::ghci::parse::lines::until_newline;
+
+use super::GhcMessage;
+
+/// Parse a `Loaded GHCi configuraton from /home/wiggles/.ghci` message.
+pub fn loaded_configuration(input: &mut &str) -> PResult<GhcMessage> {
+    let _ = "Loaded GHCi configuration from ".parse_next(input)?;
+    let path = until_newline.parse_next(input)?;
+
+    Ok(GhcMessage::LoadConfig {
+        path: Utf8PathBuf::from(path),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_loaded_ghci_configuration_message() {
+        assert_eq!(
+            loaded_configuration
+                .parse("Loaded GHCi configuration from /home/wiggles/.ghci\n")
+                .unwrap(),
+            GhcMessage::LoadConfig {
+                path: "/home/wiggles/.ghci".into()
+            }
+        );
+
+        // It shouldn't parse another line.
+        assert!(loaded_configuration
+            .parse(indoc!(
+                "
+                Loaded GHCi configuration from /home/wiggles/.ghci
+                [1 of 4] Compiling MyLib            ( src/MyLib.hs, interpreted )
+                "
+            ))
+            .is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/message_body.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/message_body.rs
@@ -1,0 +1,133 @@
+use winnow::ascii::space1;
+use winnow::combinator::alt;
+use winnow::combinator::repeat;
+use winnow::token::take_while;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::ghci::parse::lines::rest_of_line;
+
+/// Parse the rest of the line as a GHC message and then parse any additional lines after that.
+pub fn parse_message_body<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    (
+        rest_of_line,
+        repeat::<_, _, (), _, _>(0.., parse_message_body_line).recognize(),
+    )
+        .recognize()
+        .parse_next(input)
+}
+
+/// Parse a GHC diagnostic message body after the first line.
+pub fn parse_message_body_lines<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    repeat::<_, _, (), _, _>(0.., parse_message_body_line)
+        .recognize()
+        .parse_next(input)
+}
+
+/// Parse a GHC diagnostic message body line and newline.
+///
+/// Message body lines are indented or start with a line number before a pipe `|`.
+pub fn parse_message_body_line<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    (
+        alt((
+            space1.void(),
+            (take_while(1.., (' ', '\t', '0'..='9')), "|").void(),
+        )),
+        rest_of_line,
+    )
+        .recognize()
+        .parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_message_body_line() {
+        assert_eq!(
+            parse_message_body_line
+                .parse("    • Can't make a derived instance of ‘MyClass MyType’:\n")
+                .unwrap(),
+            "    • Can't make a derived instance of ‘MyClass MyType’:\n"
+        );
+        assert_eq!(
+            parse_message_body_line
+                .parse("6 |   deriving MyClass\n")
+                .unwrap(),
+            "6 |   deriving MyClass\n"
+        );
+        assert_eq!(parse_message_body_line.parse("  |\n").unwrap(), "  |\n");
+        assert_eq!(
+            parse_message_body_line
+                .parse("    Suggested fix: Perhaps you intended to use DeriveAnyClass\n")
+                .unwrap(),
+            "    Suggested fix: Perhaps you intended to use DeriveAnyClass\n"
+        );
+        assert_eq!(parse_message_body_line.parse("    \n").unwrap(), "    \n");
+
+        // Negative cases.
+        // Blank line:
+        assert!(parse_message_body_line.parse("\n").is_err());
+        // Two lines:
+        assert!(parse_message_body_line.parse("   \n\n").is_err());
+        // New error message:
+        assert!(parse_message_body_line
+            .parse("Foo.hs:8:16: Error: The syntax is wrong :(\n")
+            .is_err());
+        assert!(parse_message_body_line
+            .parse("[1 of 2] Compiling Foo ( Foo.hs, interpreted )\n")
+            .is_err());
+    }
+
+    #[test]
+    fn test_parse_message_body_lines() {
+        let src = indoc!(
+            "    • Can't make a derived instance of ‘MyClass MyType’:
+                    ‘MyClass’ is not a stock derivable class (Eq, Show, etc.)
+                • In the data declaration for ‘MyType’
+                Suggested fix: Perhaps you intended to use DeriveAnyClass
+              |
+            6 |   deriving MyClass
+              |            ^^^^^^^
+            "
+        );
+        assert_eq!(parse_message_body.parse(src).unwrap(), src);
+    }
+
+    #[test]
+    fn test_parse_message_body() {
+        let src = indoc!(
+            "[GHC-00158]
+                • Can't make a derived instance of ‘MyClass MyType’:
+                    ‘MyClass’ is not a stock derivable class (Eq, Show, etc.)
+                • In the data declaration for ‘MyType’
+                Suggested fix: Perhaps you intended to use DeriveAnyClass
+              |
+            6 |   deriving MyClass
+              |            ^^^^^^^
+            "
+        );
+        assert_eq!(parse_message_body.parse(src).unwrap(), src);
+
+        // Don't parse another error.
+        assert!(parse_message_body
+            .parse(indoc!(
+                "[GHC-00158]
+                • Can't make a derived instance of ‘MyClass MyType’:
+                    ‘MyClass’ is not a stock derivable class (Eq, Show, etc.)
+                • In the data declaration for ‘MyType’
+                Suggested fix: Perhaps you intended to use DeriveAnyClass
+              |
+            6 |   deriving MyClass
+              |            ^^^^^^^
+
+            Foo.hs:4:1: Error: I don't like it
+            "
+            ))
+            .is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/mod.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/mod.rs
@@ -1,0 +1,230 @@
+//! Parser for GHC compiler output.
+
+use camino::Utf8PathBuf;
+use miette::miette;
+use winnow::combinator::alt;
+use winnow::combinator::fold_repeat;
+use winnow::prelude::*;
+
+mod position;
+pub use position::Position;
+pub use position::PositionRange;
+
+mod severity;
+pub use severity::Severity;
+
+mod single_quote;
+
+mod path_colon;
+use path_colon::path_colon;
+
+mod compiling;
+use compiling::compiling;
+
+mod message_body;
+
+mod compilation_summary;
+use compilation_summary::compilation_summary;
+
+mod loaded_configuration;
+use loaded_configuration::loaded_configuration;
+
+mod cant_find_file_diagnostic;
+use cant_find_file_diagnostic::cant_find_file_diagnostic;
+
+mod generic_diagnostic;
+use generic_diagnostic::generic_diagnostic;
+
+mod module_import_cycle_diagnostic;
+use module_import_cycle_diagnostic::module_import_cycle_diagnostic;
+
+mod no_location_info_diagnostic;
+use no_location_info_diagnostic::no_location_info_diagnostic;
+
+use super::rest_of_line;
+use super::Module;
+
+/// A message printed by GHC or GHCi while compiling.
+///
+/// These include progress updates on compilation, errors and warnings, or GHCi messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GhcMessage {
+    /// A module being compiled.
+    ///
+    /// ```text
+    /// [1 of 2] Compiling Foo ( Foo.hs, interpreted )
+    /// ```
+    Compiling(Module),
+    /// An error or warning diagnostic message.
+    ///
+    /// ```text
+    /// Foo.hs:81:1: Warning: Defined but not used: `bar'
+    /// ```
+    Diagnostic {
+        /// The diagnostic's severity.
+        severity: Severity,
+        /// Path to the relevant file, like `src/Foo/Bar.hs`.
+        path: Option<Utf8PathBuf>,
+        /// Span for the diagnostic.
+        span: PositionRange,
+        /// The associated message.
+        message: String,
+    },
+    /// A configuration file being loaded.
+    ///
+    /// ```text
+    /// Loaded GHCi configuration from foo.ghci
+    /// ```
+    LoadConfig {
+        /// The path to the loaded configuration file.
+        path: Utf8PathBuf,
+    },
+    /// Compilation finished.
+    ///
+    /// ```text
+    /// Ok, 123 modules loaded.
+    /// ```
+    ///
+    /// Or:
+    ///
+    /// ```text
+    /// Failed, 58 modules loaded.
+    /// ```
+    Summary {
+        /// The compilation result; whether compilation succeeded or failed.
+        result: CompilationResult,
+        /// The summary message, as a string; this is displayed in the output file.
+        message: String,
+    },
+}
+
+/// The result of compiling modules in `ghci`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompilationResult {
+    /// All the modules compiled successfully.
+    Ok,
+    /// Some modules failed to compile/load.
+    Err,
+}
+
+/// Parse [`GhcMessage`]s from lines of compiler output.
+pub fn parse_ghc_messages(lines: &str) -> miette::Result<Vec<GhcMessage>> {
+    // TODO: Preserve ANSI colors somehow.
+    let uncolored_lines = strip_ansi_escapes::strip_str(lines);
+
+    parse_messages_inner
+        .parse(&uncolored_lines)
+        .map_err(|err| miette!("{err}"))
+}
+
+fn parse_messages_inner(input: &mut &str) -> PResult<Vec<GhcMessage>> {
+    enum Item {
+        One(GhcMessage),
+        Many(Vec<GhcMessage>),
+        Ignore,
+    }
+
+    fold_repeat(
+        0..,
+        alt((
+            compiling.map(Item::One),
+            generic_diagnostic.map(Item::One),
+            cant_find_file_diagnostic.map(Item::One),
+            no_location_info_diagnostic.map(Item::One),
+            module_import_cycle_diagnostic.map(Item::Many),
+            loaded_configuration.map(Item::One),
+            compilation_summary.map(Item::One),
+            rest_of_line.map(|line| {
+                tracing::debug!(line, "Ignoring GHC output line");
+                Item::Ignore
+            }),
+        )),
+        Vec::new,
+        |mut messages, item| {
+            match item {
+                Item::One(item) => messages.push(item),
+                Item::Many(items) => messages.extend(items),
+                Item::Ignore => {}
+            }
+            messages
+        },
+    )
+    .parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_messages() {
+        assert_eq!(
+            parse_ghc_messages(indoc!(
+                r#"
+                Warning: The package list for 'hackage.haskell.org' is 29 days old.
+                Run 'cabal update' to get the latest list of available packages.
+                Resolving dependencies...
+                Build profile: -w ghc-9.0.2 -O1
+                In order, the following will be built (use -v for more details):
+                 - my-simple-package-0.1.0.0 (lib:test-dev) (first run)
+                Configuring library 'test-dev' for my-simple-package-0.1.0.0..
+                Preprocessing library 'test-dev' for my-simple-package-0.1.0.0..
+                GHCi, version 9.0.2: https://www.haskell.org/ghc/  :? for help
+                Loaded GHCi configuration from /Users/wiggles/.ghci
+                [1 of 4] Compiling MyLib            ( src/MyLib.hs, interpreted )
+                [2 of 4] Compiling MyModule         ( src/MyModule.hs, interpreted )
+
+                src/MyModule.hs:4:11: error:
+                    • Couldn't match type ‘[Char]’ with ‘()’
+                      Expected: ()
+                        Actual: String
+                    • In the expression: "example"
+                      In an equation for ‘example’: example = "example"
+                  |
+                4 | example = "example"
+                  |           ^^^^^^^^^
+                Failed, one module loaded.
+                "#
+            ))
+            .unwrap(),
+            vec![
+                GhcMessage::LoadConfig {
+                    path: "/Users/wiggles/.ghci".into()
+                },
+                GhcMessage::Compiling(Module {
+                    name: "MyLib".into(),
+                    path: "src/MyLib.hs".into(),
+                }),
+                GhcMessage::Compiling(Module {
+                    name: "MyModule".into(),
+                    path: "src/MyModule.hs".into(),
+                }),
+                GhcMessage::Diagnostic {
+                    severity: Severity::Error,
+                    path: Some("src/MyModule.hs".into()),
+                    span: PositionRange::new(4, 11, 4, 11),
+                    message: [
+                        "",
+                        "    • Couldn't match type ‘[Char]’ with ‘()’",
+                        "      Expected: ()",
+                        "        Actual: String",
+                        "    • In the expression: \"example\"",
+                        "      In an equation for ‘example’: example = \"example\"",
+                        "  |",
+                        "4 | example = \"example\"",
+                        "  |           ^^^^^^^^^",
+                        "",
+                    ]
+                    .join("\n")
+                },
+                GhcMessage::Summary {
+                    result: CompilationResult::Err,
+                    message: "Failed, one module loaded.".into()
+                },
+            ]
+        );
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/module_import_cycle_diagnostic.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/module_import_cycle_diagnostic.rs
@@ -1,0 +1,180 @@
+use camino::Utf8PathBuf;
+use itertools::Itertools;
+use winnow::ascii::line_ending;
+use winnow::ascii::space1;
+use winnow::combinator::alt;
+use winnow::combinator::opt;
+use winnow::combinator::repeat;
+use winnow::token::take_until1;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::ghci::parse::ghc_message::message_body::parse_message_body_lines;
+use crate::ghci::parse::ghc_message::single_quote::single_quote;
+use crate::ghci::parse::ghc_message::GhcMessage;
+use crate::ghci::parse::haskell_grammar::module_name;
+use crate::ghci::parse::lines::rest_of_line;
+use crate::ghci::parse::Severity;
+
+/// Either:
+///
+/// ```text
+/// Module graph contains a cycle:
+///         module ‘C’ (./C.hs)
+///         imports module ‘A’ (A.hs)
+///   which imports module ‘B’ (./B.hs)
+///   which imports module ‘C’ (./C.hs)
+/// ```
+///
+/// Or:
+///
+/// ```text
+/// Module graph contains a cycle:
+///   module ‘A’ (A.hs) imports itself
+/// ```
+pub fn module_import_cycle_diagnostic(input: &mut &str) -> PResult<Vec<GhcMessage>> {
+    fn parse_import_cycle_line(input: &mut &str) -> PResult<Utf8PathBuf> {
+        let _ = space1.parse_next(input)?;
+        let _ = opt("which ").parse_next(input)?;
+        let _ = opt("imports ").parse_next(input)?;
+        let _ = "module ".parse_next(input)?;
+        let _ = single_quote.parse_next(input)?;
+        let _name = module_name.parse_next(input)?;
+        let _ = single_quote.parse_next(input)?;
+        let _ = space1.parse_next(input)?;
+        let _ = "(".parse_next(input)?;
+        let path = take_until1(")").parse_next(input)?;
+        let _ = ")".parse_next(input)?;
+        let _ = rest_of_line.parse_next(input)?;
+
+        Ok(Utf8PathBuf::from(path))
+    }
+
+    let _ = alt((
+        "Module imports form a cycle:",
+        "Module graph contains a cycle:",
+    ))
+    .parse_next(input)?;
+    let _ = line_ending.parse_next(input)?;
+    let (paths, message) = parse_message_body_lines
+        .and_then(|message: &mut &str| {
+            let full_message = message.to_owned();
+            repeat(1.., parse_import_cycle_line)
+                .parse_next(message)
+                .map(move |paths: Vec<_>| (paths, full_message))
+        })
+        .parse_next(input)?;
+
+    Ok(paths
+        .into_iter()
+        .unique()
+        .map(|path| GhcMessage::Diagnostic {
+            severity: Severity::Error,
+            path: Some(path),
+            span: Default::default(),
+            message: message.clone(),
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_module_import_cycle_message() {
+        // It's not convenient to use `indoc!` here because all of the lines have leading
+        // whitespace.
+        let message = [
+            "        module ‘C’ (./C.hs)",
+            "        imports module ‘A’ (A.hs)",
+            "  which imports module ‘B’ (./B.hs)",
+            "  which imports module ‘C’ (./C.hs)",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(
+            module_import_cycle_diagnostic
+                .parse(&format!("Module graph contains a cycle:\n{message}"))
+                .unwrap(),
+            vec![
+                GhcMessage::Diagnostic {
+                    severity: Severity::Error,
+                    path: Some("./C.hs".into()),
+                    span: Default::default(),
+                    message: message.clone()
+                },
+                GhcMessage::Diagnostic {
+                    severity: Severity::Error,
+                    path: Some("A.hs".into()),
+                    span: Default::default(),
+                    message: message.clone()
+                },
+                GhcMessage::Diagnostic {
+                    severity: Severity::Error,
+                    path: Some("./B.hs".into()),
+                    span: Default::default(),
+                    message: message.clone()
+                },
+            ]
+        );
+
+        assert_eq!(
+            module_import_cycle_diagnostic
+                .parse(&format!("Module imports form a cycle:\n{message}"))
+                .unwrap(),
+            vec![
+                GhcMessage::Diagnostic {
+                    severity: Severity::Error,
+                    path: Some("./C.hs".into()),
+                    span: Default::default(),
+                    message: message.clone()
+                },
+                GhcMessage::Diagnostic {
+                    severity: Severity::Error,
+                    path: Some("A.hs".into()),
+                    span: Default::default(),
+                    message: message.clone()
+                },
+                GhcMessage::Diagnostic {
+                    severity: Severity::Error,
+                    path: Some("./B.hs".into()),
+                    span: Default::default(),
+                    message: message.clone()
+                },
+            ]
+        );
+
+        assert_eq!(
+            module_import_cycle_diagnostic
+                .parse(indoc!(
+                    "
+                    Module graph contains a cycle:
+                      module ‘A’ (A.hs) imports itself
+                    "
+                ))
+                .unwrap(),
+            vec![GhcMessage::Diagnostic {
+                severity: Severity::Error,
+                path: Some("A.hs".into()),
+                span: Default::default(),
+                message: "  module ‘A’ (A.hs) imports itself\n".into()
+            },]
+        );
+
+        // Shouldn't parse anything after the message
+        assert!(module_import_cycle_diagnostic
+            .parse(indoc!(
+                "
+                    Module graph contains a cycle:
+                      module ‘A’ (A.hs) imports itself
+                    Error: Uh oh!
+                    "
+            ))
+            .is_err(),);
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/no_location_info_diagnostic.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/no_location_info_diagnostic.rs
@@ -1,0 +1,101 @@
+use winnow::ascii::space0;
+use winnow::ascii::space1;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::ghci::parse::ghc_message::message_body::parse_message_body;
+use crate::ghci::parse::ghc_message::position;
+use crate::ghci::parse::ghc_message::severity;
+use crate::ghci::parse::ghc_message::GhcMessage;
+
+/// Parse a message like this:
+///
+/// ```text
+/// <no location info>: error:
+///     Could not find module ‘Example’
+///     It is not a module in the current program, or in any known package.
+/// ```
+pub fn no_location_info_diagnostic(input: &mut &str) -> PResult<GhcMessage> {
+    let _ = position::parse_unhelpful_position.parse_next(input)?;
+    let _ = space1.parse_next(input)?;
+    let severity = severity::parse_severity_colon.parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+    let message = parse_message_body.parse_next(input)?;
+
+    Ok(GhcMessage::Diagnostic {
+        severity,
+        path: None,
+        span: Default::default(),
+        message: message.to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use severity::Severity;
+
+    #[test]
+    fn test_parse_no_location_info_message() {
+        // Error message from here: https://github.com/commercialhaskell/stack/issues/3582
+        let message = indoc!(
+            "
+            <no location info>: error:
+                Could not find module ‘Example’
+                It is not a module in the current program, or in any known package.
+            "
+        );
+        assert_eq!(
+            no_location_info_diagnostic.parse(message).unwrap(),
+            GhcMessage::Diagnostic {
+                severity: Severity::Error,
+                path: None,
+                span: Default::default(),
+                message: "\n    Could not find module ‘Example’\
+                    \n    It is not a module in the current program, or in any known package.\
+                    \n"
+                .into()
+            }
+        );
+
+        assert_eq!(
+            no_location_info_diagnostic
+                .parse(indoc!(
+                    "
+                    <no location info>: error: [GHC-29235]
+                        module 'dwb-0-inplace-test-dev:Foo' is defined in multiple files: src/Foo.hs
+                                                                                          src/Foo.hs
+                    "
+                ))
+                .unwrap(),
+            GhcMessage::Diagnostic {
+                severity: Severity::Error,
+                path: None,
+                span: Default::default(),
+                message: indoc!(
+                    "
+                    [GHC-29235]
+                        module 'dwb-0-inplace-test-dev:Foo' is defined in multiple files: src/Foo.hs
+                                                                                          src/Foo.hs
+                    "
+                )
+                .into()
+            }
+        );
+
+        // Shouldn't parse another error.
+        assert!(no_location_info_diagnostic
+            .parse(indoc!(
+                "
+                <no location info>: error: [GHC-29235]
+                    module 'dwb-0-inplace-test-dev:Foo' is defined in multiple files: src/Foo.hs
+                                                                                      src/Foo.hs
+                Error: Uh oh!
+                "
+            ))
+            .is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/path_colon.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/path_colon.rs
@@ -1,0 +1,51 @@
+use camino::Utf8Path;
+use winnow::combinator::terminated;
+use winnow::token::take_till1;
+use winnow::PResult;
+use winnow::Parser;
+
+/// A filename, followed by a `:`.
+pub fn path_colon<'i>(input: &mut &'i str) -> PResult<&'i Utf8Path> {
+    // TODO: Support Windows drive letters.
+    terminated(take_till1((':', '\n')), ":")
+        .parse_next(input)
+        .map(Utf8Path::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_path_colon() {
+        assert_eq!(
+            path_colon.parse("./Foo.hs:").unwrap(),
+            Utf8Path::new("./Foo.hs")
+        );
+        assert_eq!(
+            path_colon.parse("../Foo.hs:").unwrap(),
+            Utf8Path::new("../Foo.hs")
+        );
+        assert_eq!(
+            path_colon.parse("foo/../Bar/./../../Foo/Foo.hs:").unwrap(),
+            Utf8Path::new("foo/../Bar/./../../Foo/Foo.hs")
+        );
+        assert_eq!(
+            path_colon.parse("Foo/Bar.hs:").unwrap(),
+            Utf8Path::new("Foo/Bar.hs")
+        );
+        assert_eq!(
+            path_colon.parse("/home/wiggles/Foo/Bar.hs:").unwrap(),
+            Utf8Path::new("/home/wiggles/Foo/Bar.hs")
+        );
+
+        // Whitespace
+        assert!(path_colon.parse("/home/wiggles/Foo/Bar.hs: ").is_err());
+        // Newline in the middle!
+        assert!(path_colon.parse("/home/wiggles\n/Foo/Bar.hs:").is_err());
+        // Missing colon.
+        assert!(path_colon.parse("/home/wiggles/Foo/Bar.hs").is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/position.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/position.rs
@@ -1,0 +1,177 @@
+use winnow::ascii::digit1;
+use winnow::combinator::alt;
+use winnow::combinator::opt;
+use winnow::combinator::preceded;
+use winnow::PResult;
+use winnow::Parser;
+
+/// A position in a file.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Position {
+    /// 1-based line number.
+    line: usize,
+    /// 1-based column number.
+    column: usize,
+}
+
+impl Position {
+    /// Construct a new [`Position`] from a line and column number.
+    #[cfg(test)]
+    pub fn new(line: usize, column: usize) -> Self {
+        Self { line, column }
+    }
+}
+
+/// A range (span) of positions in a file.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PositionRange {
+    /// The start position.
+    start: Position,
+    /// The end position. If the span is zero-length, this will be the same as the start position.
+    end: Position,
+}
+
+impl PositionRange {
+    /// Construct a new span from the given lines and columns.
+    #[cfg(test)]
+    pub fn new(start_line: usize, start_column: usize, end_line: usize, end_column: usize) -> Self {
+        Self {
+            start: Position::new(start_line, start_column),
+            end: Position::new(end_line, end_column),
+        }
+    }
+}
+
+/// A position range in a GHC diagnostic, followed by a colon.
+///
+/// One of these formats:
+/// ```text
+/// 1:2:               # Zero-length, `line:column:`
+/// 1:2-4:             # Single-line, `line:startColumn-endColumn:`
+/// (1,2)-(3,4):       # Multi-line, `(startLine,startColumn)-(endLine,endColumn):`
+/// ```
+///
+/// See:
+/// <https://gitlab.haskell.org/ghc/ghc/-/blob/288235bbe5a59b8a1bda80aaacd59e5717417726/compiler/GHC/Types/SrcLoc.hs#L348-L355>
+pub fn parse_position_range(input: &mut &str) -> PResult<PositionRange> {
+    fn parse_full_position_range(input: &mut &str) -> PResult<PositionRange> {
+        let _ = "(".parse_next(input)?;
+        let start_line = digit1.parse_to().parse_next(input)?;
+        let _ = ",".parse_next(input)?;
+        let start_column = digit1.parse_to().parse_next(input)?;
+        let _ = ")-(".parse_next(input)?;
+        let end_line = digit1.parse_to().parse_next(input)?;
+        let _ = ",".parse_next(input)?;
+        let end_column = digit1.parse_to().parse_next(input)?;
+        let _ = ")".parse_next(input)?;
+        let _ = ":".parse_next(input)?;
+
+        Ok(PositionRange {
+            start: Position {
+                line: start_line,
+                column: start_column,
+            },
+            end: Position {
+                line: end_line,
+                column: end_column,
+            },
+        })
+    }
+
+    fn parse_single_line_position_range(input: &mut &str) -> PResult<PositionRange> {
+        let line = digit1.parse_to().parse_next(input)?;
+        let _ = ":".parse_next(input)?;
+        let start_column = digit1.parse_to().parse_next(input)?;
+        // Get the end column, if any.
+        let end_column = opt(preceded("-", digit1.parse_to()))
+            .parse_next(input)?
+            .unwrap_or(start_column);
+        let _ = ":".parse_next(input)?;
+        Ok(PositionRange {
+            start: Position {
+                line,
+                column: start_column,
+            },
+            end: Position {
+                line,
+                column: end_column,
+            },
+        })
+    }
+
+    alt((parse_full_position_range, parse_single_line_position_range)).parse_next(input)
+}
+
+/// Parse an "unhelpful" source location like `<no location info>` followed by a colon. There's a
+/// few of these.
+///
+/// See: https://gitlab.haskell.org/ghc/ghc/-/blob/288235bbe5a59b8a1bda80aaacd59e5717417726/compiler/GHC/Types/SrcLoc.hs#L251-L253
+pub fn parse_unhelpful_position<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    alt((
+        "<no location info>:",
+        "<compiler-generated code>:",
+        "<interactive>:",
+    ))
+    .parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_position_range() {
+        // Zero-length.
+        assert_eq!(
+            parse_position_range.parse("1:2:").unwrap(),
+            PositionRange::new(1, 2, 1, 2)
+        );
+        assert_eq!(
+            parse_position_range.parse("4258:12859:").unwrap(),
+            PositionRange::new(4258, 12859, 4258, 12859)
+        );
+
+        // Single-line.
+        assert_eq!(
+            parse_position_range.parse("1:2-3:").unwrap(),
+            PositionRange::new(1, 2, 1, 3)
+        );
+        assert_eq!(
+            parse_position_range.parse("621:284-312:").unwrap(),
+            PositionRange::new(621, 284, 621, 312)
+        );
+
+        // Multi-line.
+        assert_eq!(
+            parse_position_range.parse("(1,2)-(3,4):").unwrap(),
+            PositionRange::new(1, 2, 3, 4)
+        );
+        assert_eq!(
+            parse_position_range.parse("(04,30)-(19,98):").unwrap(),
+            PositionRange::new(4, 30, 19, 98)
+        );
+        assert_eq!(
+            parse_position_range.parse("(571,643)-(5466,123):").unwrap(),
+            PositionRange::new(571, 643, 5466, 123)
+        );
+
+        // Negative cases.
+        // Whitespace:
+        assert!(parse_position_range.parse(" 1:2:").is_err());
+        assert!(parse_position_range.parse("1:2: ").is_err());
+        assert!(parse_position_range.parse("1 :2:").is_err());
+        assert!(parse_position_range.parse("1: 2:").is_err());
+        assert!(parse_position_range.parse("1:2 :").is_err());
+        assert!(parse_position_range.parse("1:2 -3:").is_err());
+        assert!(parse_position_range.parse("(1, 2)-(3, 4):").is_err());
+        assert!(parse_position_range.parse("(1,2) - (3,4):").is_err());
+        assert!(parse_position_range.parse(" (1,2)-(3,4):").is_err());
+
+        // Missing parens:
+        assert!(parse_position_range.parse("1,2-3,4:").is_err());
+        // Extra parens:
+        assert!(parse_position_range.parse("(1:2):").is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/severity.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/severity.rs
@@ -1,0 +1,63 @@
+use winnow::combinator::dispatch;
+use winnow::combinator::fail;
+use winnow::combinator::success;
+use winnow::combinator::terminated;
+use winnow::token::take_until1;
+use winnow::PResult;
+use winnow::Parser;
+
+/// The severity of a compiler message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Warning-level; non-fatal.
+    Warning,
+    /// Error-level; fatal.
+    Error,
+}
+
+/// Parse a severity followed by a `:`, either `Warning` or `Error`.
+pub fn parse_severity_colon(input: &mut &str) -> PResult<Severity> {
+    terminated(
+        dispatch! {take_until1(":");
+            "warning"|"Warning" => success(Severity::Warning),
+            "error"|"Error" => success(Severity::Error),
+            _ => fail,
+        },
+        ":",
+    )
+    .parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_severity() {
+        assert_eq!(
+            parse_severity_colon.parse("Warning:").unwrap(),
+            Severity::Warning
+        );
+        assert_eq!(
+            parse_severity_colon.parse("warning:").unwrap(),
+            Severity::Warning
+        );
+        assert_eq!(
+            parse_severity_colon.parse("Error:").unwrap(),
+            Severity::Error
+        );
+        assert_eq!(
+            parse_severity_colon.parse("error:").unwrap(),
+            Severity::Error
+        );
+
+        // Negative cases.
+        assert!(parse_severity_colon.parse(" Error:").is_err());
+        assert!(parse_severity_colon.parse("Error :").is_err());
+        assert!(parse_severity_colon.parse("Error: ").is_err());
+        assert!(parse_severity_colon.parse(" Warning:").is_err());
+        assert!(parse_severity_colon.parse("Warning :").is_err());
+        assert!(parse_severity_colon.parse("Warning: ").is_err());
+        assert!(parse_severity_colon.parse("W arning:").is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/ghc_message/single_quote.rs
+++ b/ghcid-ng/src/ghci/parse/ghc_message/single_quote.rs
@@ -1,0 +1,39 @@
+use winnow::token::one_of;
+use winnow::PResult;
+use winnow::Parser;
+
+/// Parse a single quote as GHC prints them.
+///
+/// These may either be "GNU-style" quotes:
+///
+/// ```text
+/// `foo'
+/// ```
+///
+/// Or Unicode single quotes:
+/// ```text
+/// ‘foo’
+/// ```
+pub fn single_quote(input: &mut &str) -> PResult<char> {
+    one_of(['`', '\'', '‘', '’']).parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_single_quote() {
+        assert_eq!(single_quote.parse("\'").unwrap(), '\'');
+        assert_eq!(single_quote.parse("`").unwrap(), '`');
+        assert_eq!(single_quote.parse("‘").unwrap(), '‘');
+        assert_eq!(single_quote.parse("’").unwrap(), '’');
+
+        assert!(single_quote.parse("''").is_err());
+        assert!(single_quote.parse(" '").is_err());
+        assert!(single_quote.parse("' ").is_err());
+        assert!(single_quote.parse("`foo'").is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/lines.rs
+++ b/ghcid-ng/src/ghci/parse/lines.rs
@@ -1,0 +1,48 @@
+use winnow::combinator::terminated;
+use winnow::token::take_until0;
+use winnow::PResult;
+use winnow::Parser;
+
+/// Parse the rest of a line, including the newline character.
+pub fn rest_of_line<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    until_newline.recognize().parse_next(input)
+}
+
+/// Parse the rest of a line, including the newline character, but do not return the newline
+/// character in the output.
+pub fn until_newline<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    terminated(take_until0("\n"), "\n").parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_rest_of_line() {
+        assert_eq!(rest_of_line.parse("\n").unwrap(), "\n");
+        assert_eq!(rest_of_line.parse("foo\n").unwrap(), "foo\n");
+        assert_eq!(rest_of_line.parse("foo bar.?\n").unwrap(), "foo bar.?\n");
+
+        // Negative cases.
+        // Missing newline:
+        assert!(rest_of_line.parse("foo").is_err());
+        // Two newlines:
+        assert!(rest_of_line.parse("foo\n\n").is_err());
+    }
+
+    #[test]
+    fn test_parse_until_newline() {
+        assert_eq!(until_newline.parse("\n").unwrap(), "");
+        assert_eq!(until_newline.parse("foo\n").unwrap(), "foo");
+        assert_eq!(until_newline.parse("foo bar.?\n").unwrap(), "foo bar.?");
+
+        // Negative cases.
+        // Missing newline:
+        assert!(until_newline.parse("foo").is_err());
+        // Two newlines:
+        assert!(until_newline.parse("foo\n\n").is_err());
+    }
+}

--- a/ghcid-ng/src/ghci/parse/mod.rs
+++ b/ghcid-ng/src/ghci/parse/mod.rs
@@ -1,10 +1,20 @@
 //! Parsers for `ghci` output.
 
+mod ghc_message;
 mod haskell_grammar;
+mod lines;
 mod module_and_files;
 mod module_set;
 
 use haskell_grammar::module_name;
+use lines::rest_of_line;
+use module_and_files::module_and_files;
 
+pub use ghc_message::parse_ghc_messages;
+pub use ghc_message::CompilationResult;
+pub use ghc_message::GhcMessage;
+pub use ghc_message::Position;
+pub use ghc_message::PositionRange;
+pub use ghc_message::Severity;
 pub use module_and_files::Module;
 pub use module_set::ModuleSet;

--- a/ghcid-ng/src/ghci/parse/module_set.rs
+++ b/ghcid-ng/src/ghci/parse/module_set.rs
@@ -35,13 +35,11 @@ impl ModuleSet {
     }
 
     /// Determine if this set is empty.
-    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Remove all entries from this set, leaving it empty.
-    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.set.clear();
     }
@@ -66,7 +64,6 @@ impl ModuleSet {
     /// Returns whether the path was present in the set.
     ///
     /// Returns `Err` if the `path` cannot be canonicalized.
-    #[allow(dead_code)]
     pub fn remove_source_path(&mut self, path: &Utf8Path) -> miette::Result<bool> {
         Ok(self.set.remove(&canonicalize(path)?))
     }

--- a/ghcid-ng/src/ghci/stderr.rs
+++ b/ghcid-ng/src/ghci/stderr.rs
@@ -119,7 +119,7 @@ impl GhciStderr {
         Ok(())
     }
 
-    #[instrument(skip(self), level = "debug")]
+    #[instrument(skip(self), level = "trace")]
     async fn ingest_line(&mut self, line: String) {
         // We might not have a buffer for some modes, e.g. `Internal`.
         if let Some(buffer) = self.buffers.get_mut(&self.mode) {
@@ -145,7 +145,7 @@ impl GhciStderr {
             let mut writer = BufWriter::new(file);
 
             if !self.compilation_summary.is_empty() {
-                tracing::debug!(?path, "Writing error log headline");
+                tracing::debug!(%path, "Writing error log headline");
                 writer
                     .write_all(self.compilation_summary.as_bytes())
                     .await
@@ -154,7 +154,7 @@ impl GhciStderr {
             }
 
             for (mode, buffer) in &self.buffers {
-                tracing::debug!(?path, %mode, bytes = buffer.len(), "Writing error log");
+                tracing::debug!(%path, %mode, bytes = buffer.len(), "Writing error log");
                 writer
                     .write_all(&strip_ansi_escapes::strip(buffer.as_bytes()))
                     .await
@@ -171,7 +171,7 @@ impl GhciStderr {
         Ok(())
     }
 
-    #[instrument(skip(self, sender), level = "debug")]
+    #[instrument(skip(self, sender), level = "trace")]
     async fn set_mode(&mut self, sender: oneshot::Sender<()>, mode: Mode) {
         self.mode = mode;
 

--- a/ghcid-ng/src/ghci/stdin.rs
+++ b/ghcid-ng/src/ghci/stdin.rs
@@ -44,7 +44,7 @@ impl GhciStdin {
         stdout.prompt(None).await
     }
 
-    #[instrument(skip(self, stdout), level = "debug")]
+    #[instrument(skip(self, stdout), name = "stdin_initialize", level = "debug")]
     pub async fn initialize(
         &mut self,
         stdout: &mut GhciStdout,
@@ -62,7 +62,7 @@ impl GhciStdin {
         .await?;
 
         for command in setup_commands {
-            tracing::debug!(?command, "Running user intialization command");
+            tracing::debug!(command, "Running user intialization command");
             self.write_line(stdout, &format!("{command}\n")).await?;
         }
 
@@ -83,7 +83,7 @@ impl GhciStdin {
     ) -> miette::Result<()> {
         if let Some(test_command) = test_command {
             self.set_mode(stdout, Mode::Testing).await?;
-            tracing::debug!(command = ?test_command, "Running user test command");
+            tracing::debug!(command = test_command, "Running user test command");
             tracing::info!("Running tests");
             let start_time = Instant::now();
             self.write_line(stdout, &format!("{test_command}\n"))
@@ -114,7 +114,7 @@ impl GhciStdin {
         self.write_line(stdout, &format!(":add {path}\n")).await
     }
 
-    #[instrument(skip(self, stdout), level = "debug")]
+    #[instrument(skip(self, stdout), level = "trace")]
     pub async fn sync(
         &mut self,
         stdout: &mut GhciStdout,
@@ -146,7 +146,7 @@ impl GhciStdin {
         stdout.show_modules().await
     }
 
-    #[instrument(skip(self, stdout), level = "debug")]
+    #[instrument(skip(self, stdout), level = "trace")]
     pub async fn set_mode(&mut self, stdout: &mut GhciStdout, mode: Mode) -> miette::Result<()> {
         let mut set = JoinSet::<Result<(), oneshot::error::RecvError>>::new();
 

--- a/ghcid-ng/src/ghci/stdout.rs
+++ b/ghcid-ng/src/ghci/stdout.rs
@@ -111,7 +111,7 @@ impl GhciStdout {
         Ok(result)
     }
 
-    #[instrument(skip_all, level = "debug")]
+    #[instrument(skip_all, level = "trace")]
     pub async fn sync(&mut self, sentinel: SyncSentinel) -> miette::Result<()> {
         // Read until the sync marker...
         let sync_pattern = AhoCorasick::from_anchored_patterns([sentinel.to_string()]);

--- a/ghcid-ng/src/ghci/stdout.rs
+++ b/ghcid-ng/src/ghci/stdout.rs
@@ -98,16 +98,6 @@ impl GhciStdout {
             Vec::new()
         };
 
-        // Tell the stderr stream to write the error log and then finish.
-        {
-            let (sender, receiver) = oneshot::channel();
-            self.stderr_sender
-                .send(StderrEvent::Write(sender))
-                .await
-                .into_diagnostic()?;
-            receiver.await.into_diagnostic()?;
-        }
-
         Ok(result)
     }
 

--- a/ghcid-ng/src/ghci/stdout.rs
+++ b/ghcid-ng/src/ghci/stdout.rs
@@ -1,9 +1,6 @@
-use std::sync::OnceLock;
-
 use aho_corasick::AhoCorasick;
 use miette::Context;
 use miette::IntoDiagnostic;
-use regex::Regex;
 use tokio::io::Stdout;
 use tokio::process::ChildStdout;
 use tokio::sync::mpsc;
@@ -15,9 +12,10 @@ use crate::incremental_reader::IncrementalReader;
 use crate::incremental_reader::WriteBehavior;
 use crate::sync_sentinel::SyncSentinel;
 
+use super::parse::parse_ghc_messages;
+use super::parse::GhcMessage;
 use super::parse::ModuleSet;
 use super::stderr::StderrEvent;
-use super::CompilationResult;
 use super::Mode;
 
 pub struct GhciStdout {
@@ -35,8 +33,8 @@ pub struct GhciStdout {
 }
 
 impl GhciStdout {
-    #[instrument(skip_all, level = "debug")]
-    pub async fn initialize(&mut self) -> miette::Result<()> {
+    #[instrument(skip_all, name = "stdout_initialize", level = "debug")]
+    pub async fn initialize(&mut self) -> miette::Result<Vec<GhcMessage>> {
         // Wait for `ghci` to start up. This may involve compiling a bunch of stuff.
         let bootup_patterns = AhoCorasick::from_anchored_patterns([
             "GHCi, version ",
@@ -51,10 +49,10 @@ impl GhciStdout {
 
         // We know that we'll get _one_ `ghci> ` prompt on startup.
         let init_prompt_patterns = AhoCorasick::from_anchored_patterns(["ghci> "]);
-        self.prompt(Some(&init_prompt_patterns)).await?;
+        let messages = self.prompt(Some(&init_prompt_patterns)).await?;
         tracing::debug!("Saw initial `ghci> ` prompt");
 
-        Ok(())
+        Ok(messages)
     }
 
     #[instrument(skip_all, level = "debug")]
@@ -66,7 +64,7 @@ impl GhciStdout {
         // compiler doesn't know we don't mess with `self.prompt_patterns` in here. So we use
         // `None` to represent that case and handle the default inline.
         prompt_patterns: Option<&AhoCorasick>,
-    ) -> miette::Result<Option<CompilationResult>> {
+    ) -> miette::Result<Vec<GhcMessage>> {
         let prompt_patterns = prompt_patterns.unwrap_or(&self.prompt_patterns);
         let data = self
             .reader
@@ -78,13 +76,27 @@ impl GhciStdout {
             .await?;
         tracing::debug!(bytes = data.len(), "Got data from ghci");
 
-        let mut result = None;
-        if self.mode == Mode::Compiling {
-            result = self
-                .get_status_from_compile_output(data.lines().last())
-                .await
-                .wrap_err("Failed to get status from compilation output")?;
-        }
+        let result = if self.mode == Mode::Compiling {
+            // Parse GHCi output into compiler messages.
+            //
+            // These include diagnostics, which modules were compiled, and a compilation summary.
+            let stderr_data = {
+                let (sender, receiver) = oneshot::channel();
+                let _ = self
+                    .stderr_sender
+                    .send(StderrEvent::GetBuffer { sender })
+                    .await;
+                receiver.await.into_diagnostic()?
+            };
+            let mut messages =
+                parse_ghc_messages(&data).wrap_err("Failed to parse compiler output")?;
+            messages.extend(
+                parse_ghc_messages(&stderr_data).wrap_err("Failed to parse compiler output")?,
+            );
+            messages
+        } else {
+            Vec::new()
+        };
 
         // Tell the stderr stream to write the error log and then finish.
         {
@@ -135,57 +147,7 @@ impl GhciStdout {
         ModuleSet::from_lines(&lines)
     }
 
-    #[instrument(skip(self), level = "debug")]
     pub fn set_mode(&mut self, mode: Mode) {
         self.mode = mode;
     }
-
-    /// Get the compilation status from a chunk of lines. The compilation status is on the last
-    /// line.
-    ///
-    /// The outer result fails if any of the operation failed, the inner `Option` conveys the
-    /// compilation status.
-    async fn get_status_from_compile_output(
-        &mut self,
-        last_line: Option<&str>,
-    ) -> miette::Result<Option<CompilationResult>> {
-        if let Some(line) = last_line {
-            if compilation_finished_re().is_match(line) {
-                let result = if line.starts_with("Ok") {
-                    tracing::debug!("Compilation succeeded");
-                    CompilationResult::Ok
-                } else {
-                    tracing::debug!("Compilation failed");
-                    CompilationResult::Err
-                };
-
-                let (sender, receiver) = oneshot::channel();
-                self.stderr_sender
-                    .send(StderrEvent::SetCompilationSummary {
-                        summary: line.to_owned(),
-                        sender,
-                    })
-                    .await
-                    .into_diagnostic()?;
-                receiver.await.into_diagnostic()?;
-
-                return Ok(Some(result));
-            } else {
-                tracing::debug!("Didn't parse 'modules loaded' line");
-            }
-        }
-
-        Ok(None)
-    }
-}
-
-fn compilation_finished_re() -> &'static Regex {
-    // There's special cases for 0-6 modules!
-    // https://gitlab.haskell.org/ghc/ghc/-/blob/288235bbe5a59b8a1bda80aaacd59e5717417726/ghc/GHCi/UI.hs#L2286-L2287
-    // https://gitlab.haskell.org/ghc/ghc/-/blob/288235bbe5a59b8a1bda80aaacd59e5717417726/compiler/GHC/Utils/Outputable.hs#L1429-L1453
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"^(?:Ok|Failed), (?:no|one|two|three|four|five|six|[0-9]+) modules? loaded.$")
-            .unwrap()
-    })
 }

--- a/ghcid-ng/src/incremental_reader.rs
+++ b/ghcid-ng/src/incremental_reader.rs
@@ -249,7 +249,7 @@ where
         }
 
         let line = std::mem::replace(&mut self.line, String::with_capacity(LINE_BUFFER_CAPACITY));
-        tracing::debug!(line, "Read line");
+        tracing::trace!(line, "Read line");
         self.lines.push_str(&line);
         self.lines.push('\n');
 

--- a/ghcid-ng/tests/basic.rs
+++ b/ghcid-ng/tests/basic.rs
@@ -117,7 +117,7 @@ async fn can_reload_after_error() {
         .unwrap();
 
     session
-        .wait_until_add()
+        .wait_until_reload()
         .await
         .expect("ghcid-ng reloads on changes");
     session
@@ -173,9 +173,9 @@ async fn can_restart_after_module_move() {
 
     session
         .get_log(
-            Matcher::message("Read line")
+            Matcher::message("Compiling")
                 .in_span("reload")
-                .with_field("line", r"Compiling My\.CoolModule"),
+                .with_field("module", r"My\.CoolModule"),
         )
         .await
         .unwrap();

--- a/ghcid-ng/tests/error_log.rs
+++ b/ghcid-ng/tests/error_log.rs
@@ -116,7 +116,7 @@ async fn can_write_error_log_compilation_errors() {
         .unwrap();
 
     session
-        .wait_until_add()
+        .wait_until_reload()
         .await
         .expect("ghcid-ng reloads on changes");
 

--- a/ghcid-ng/tests/failed_modules.rs
+++ b/ghcid-ng/tests/failed_modules.rs
@@ -1,0 +1,35 @@
+use test_harness::fs;
+use test_harness::test;
+use test_harness::GhcidNgBuilder;
+
+/// Test that `ghcid-ng` can start with compile errors.
+///
+/// This is a regression test for [#43](https://github.com/MercuryTechnologies/ghcid-ng/issues/43).
+#[test]
+async fn can_start_with_failed_modules() {
+    let module_path = "src/MyModule.hs";
+    let mut session = GhcidNgBuilder::new("tests/data/simple")
+        .before_start(move |path| async move {
+            fs::replace(path.join(module_path), "example :: String", "example :: ()").await
+        })
+        .start()
+        .await
+        .expect("ghcid-ng starts");
+    let module_path = session.path(module_path);
+
+    session
+        .get_log("Compilation failed")
+        .await
+        .expect("ghcid-ng fails to load with errors");
+
+    session.wait_until_ready().await.expect("ghcid-ng loads");
+
+    fs::replace(&module_path, "example :: ()", "example :: String")
+        .await
+        .unwrap();
+
+    session
+        .get_log("Compilation succeeded")
+        .await
+        .expect("ghcid-ng reloads fixed modules");
+}

--- a/test-harness/src/ghcid_ng.rs
+++ b/test-harness/src/ghcid_ng.rs
@@ -124,7 +124,12 @@ impl GhcidNg {
                 "--before-startup-shell",
                 "hpack --force .",
                 "--tracing-filter",
-                "ghcid_ng::watcher=trace,ghcid_ng=debug,watchexec=debug,watchexec::fs=trace",
+                &[
+                    "ghcid_ng::watcher=trace",
+                    "ghcid_ng=debug",
+                    "watchexec=debug",
+                    "watchexec::fs=trace",
+                ].join(","),
                 "--trace-spans",
                 "new,close",
                 "--poll",

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -119,7 +119,7 @@ async fn cleanup() {
                         .expect("Failed to kill `ghcid-ng` after test completion");
                 }
                 Ok(Ok(status)) => {
-                    tracing::info!(?status, "ghcid-ng exited");
+                    tracing::info!(%status, "ghcid-ng exited");
                 }
                 Ok(Err(err)) => {
                     tracing::error!("Waiting for ghcid-ng to exit failed: {err}");

--- a/test-harness/src/tracing_reader.rs
+++ b/test-harness/src/tracing_reader.rs
@@ -48,7 +48,9 @@ impl TracingReader {
 
         while let Some(duration) = backoff.next_backoff() {
             if let Some(line) = self.lines.next_line().await.into_diagnostic()? {
-                let event = serde_json::from_str(&line).into_diagnostic()?;
+                let event = serde_json::from_str(&line)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("Failed to deserialize JSON: {line}"))?;
                 return Ok(event);
             }
             tokio::time::sleep(duration).await;


### PR DESCRIPTION
This parses GHC diagnostics and uses the output to avoid `:add`ing failed modules. See the bug upstream here: https://gitlab.haskell.org/ghc/ghc/-/issues/13254