### PR TITLE
Make `--errors` output compatible with `ghcid`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,6 @@ dependencies = [
  "tap",
  "test-harness",
  "textwrap 0.16.0",
- "time",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ shell-words = "1.1.0"
 strip-ansi-escapes = "0.2.0"
 tap = "1.0.1"
 textwrap = { version = "0.16.0", features = ["terminal_size"] }
-time = { version = "0.3.22", features = ["formatting"] }
 tokio = { version = "1.28.2", features = ["full", "tracing"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "time", "json", "registry"] }

--- a/src/ghci/error_log.rs
+++ b/src/ghci/error_log.rs
@@ -1,0 +1,75 @@
+use camino::Utf8PathBuf;
+use miette::IntoDiagnostic;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufWriter;
+use tracing::instrument;
+
+use super::parse::CompilationResult;
+use super::parse::CompilationSummary;
+use super::parse::GhcMessage;
+
+/// Error log writer.
+///
+/// This produces `ghcid`-compatible output, which can be consumed by `ghcid` plugins in your
+/// editor of choice.
+pub struct ErrorLog {
+    path: Option<Utf8PathBuf>,
+}
+
+impl ErrorLog {
+    /// Construct a new error log writer for the given path.
+    pub fn new(path: Option<Utf8PathBuf>) -> Self {
+        Self { path }
+    }
+
+    /// Write the error log, if any, with the given compilation summary and diagnostic messages.
+    #[instrument(skip(self, messages), name = "error_log_write", level = "debug")]
+    pub async fn write(
+        &mut self,
+        compilation_summary: Option<CompilationSummary>,
+        messages: &[GhcMessage],
+    ) -> miette::Result<()> {
+        let path = match &self.path {
+            Some(path) => path,
+            None => {
+                tracing::debug!("No error log path, not writing");
+                return Ok(());
+            }
+        };
+
+        let file = File::create(path).await.into_diagnostic()?;
+        let mut writer = BufWriter::new(file);
+
+        if let Some(summary) = compilation_summary {
+            // `ghcid` only writes the headline if there's no errors.
+            if let CompilationResult::Ok = summary.result {
+                tracing::debug!(%path, "Writing 'All good'");
+                let modules_loaded = if summary.modules_loaded != 1 {
+                    format!("{} modules", summary.modules_loaded)
+                } else {
+                    format!("{} module", summary.modules_loaded)
+                };
+                writer
+                    .write_all(format!("All good ({modules_loaded})\n").as_bytes())
+                    .await
+                    .into_diagnostic()?;
+            }
+        }
+
+        for message in messages {
+            if let GhcMessage::Diagnostic(diagnostic) = message {
+                writer
+                    .write_all(diagnostic.to_string().as_bytes())
+                    .await
+                    .into_diagnostic()?;
+            }
+        }
+
+        // This is load-bearing! If we don't properly flush/shutdown the handle, nothing gets
+        // written!
+        writer.shutdown().await.into_diagnostic()?;
+
+        Ok(())
+    }
+}

--- a/src/ghci/parse/ghc_message/message_body.rs
+++ b/src/ghci/parse/ghc_message/message_body.rs
@@ -17,13 +17,6 @@ pub fn parse_message_body<'i>(input: &mut &'i str) -> PResult<&'i str> {
         .parse_next(input)
 }
 
-/// Parse a GHC diagnostic message body after the first line.
-pub fn parse_message_body_lines<'i>(input: &mut &'i str) -> PResult<&'i str> {
-    repeat::<_, _, (), _, _>(0.., parse_message_body_line)
-        .recognize()
-        .parse_next(input)
-}
-
 /// Parse a GHC diagnostic message body line and newline.
 ///
 /// Message body lines are indented or start with a line number before a pipe `|`.
@@ -84,7 +77,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_message_body_lines() {
+    fn test_parse_message_body() {
         let src = indoc!(
             "    • Can't make a derived instance of ‘MyClass MyType’:
                     ‘MyClass’ is not a stock derivable class (Eq, Show, etc.)
@@ -96,10 +89,7 @@ mod tests {
             "
         );
         assert_eq!(parse_message_body.parse(src).unwrap(), src);
-    }
 
-    #[test]
-    fn test_parse_message_body() {
         let src = indoc!(
             "[GHC-00158]
                 • Can't make a derived instance of ‘MyClass MyType’:

--- a/src/ghci/parse/ghc_message/severity.rs
+++ b/src/ghci/parse/ghc_message/severity.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use winnow::combinator::dispatch;
 use winnow::combinator::fail;
 use winnow::combinator::success;
@@ -13,6 +15,15 @@ pub enum Severity {
     Warning,
     /// Error-level; fatal.
     Error,
+}
+
+impl Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Severity::Warning => write!(f, "warning"),
+            Severity::Error => write!(f, "error"),
+        }
+    }
 }
 
 /// Parse a severity followed by a `:`, either `Warning` or `Error`.
@@ -59,5 +70,11 @@ mod tests {
         assert!(parse_severity_colon.parse("Warning :").is_err());
         assert!(parse_severity_colon.parse("Warning: ").is_err());
         assert!(parse_severity_colon.parse("W arning:").is_err());
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(Severity::Error.to_string(), "error");
+        assert_eq!(Severity::Warning.to_string(), "warning");
     }
 }

--- a/src/ghci/parse/mod.rs
+++ b/src/ghci/parse/mod.rs
@@ -12,6 +12,8 @@ use module_and_files::module_and_files;
 
 pub use ghc_message::parse_ghc_messages;
 pub use ghc_message::CompilationResult;
+pub use ghc_message::CompilationSummary;
+pub use ghc_message::GhcDiagnostic;
 pub use ghc_message::GhcMessage;
 pub use ghc_message::Position;
 pub use ghc_message::PositionRange;

--- a/src/ghci/stderr.rs
+++ b/src/ghci/stderr.rs
@@ -1,13 +1,6 @@
-use std::collections::BTreeMap;
-
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
-use camino::Utf8PathBuf;
-use miette::IntoDiagnostic;
-use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
-use tokio::io::BufWriter;
 use tokio::io::Lines;
 use tokio::process::ChildStderr;
 use tokio::sync::mpsc;
@@ -19,15 +12,6 @@ use super::Mode;
 /// An event sent to a `ghci` session's stderr channel.
 #[derive(Debug)]
 pub enum StderrEvent {
-    /// Write to the `error_path` (`ghcid.txt`) file, if any.
-    Write(oneshot::Sender<()>),
-
-    /// Set the compilation summary to the given string.
-    SetCompilationSummary {
-        summary: String,
-        sender: oneshot::Sender<()>,
-    },
-
     /// Set the writer's mode.
     Mode {
         mode: Mode,
@@ -41,23 +25,10 @@ pub enum StderrEvent {
 pub struct GhciStderr {
     pub reader: Lines<BufReader<ChildStderr>>,
     pub receiver: mpsc::Receiver<StderrEvent>,
-    /// A headline to write to the error log.
-    ///
-    /// This is a summary of the `ghci` session's status. Typically taken from compilation output,
-    /// of the form `(Ok|Failed), [0-9]+ modules loaded.`.
-    pub compilation_summary: String,
-    /// Output buffers, one per [`Mode`]. This lets us gather output for compilation and tests
-    /// separately. Useful to avoid clobbering the `error_path` with test data when there were
-    /// useful compilation errors stored.
-    pub buffers: BTreeMap<Mode, String>,
     /// Output buffer.
     pub buffer: String,
-    /// The path to write the error log to.
-    pub error_path: Option<Utf8PathBuf>,
     /// The mode we're currently reading output in.
     pub mode: Mode,
-    /// `true` if we've read data from stderr but not yet written it to the error log.
-    pub has_unwritten_data: bool,
 }
 
 impl GhciStderr {
@@ -100,16 +71,8 @@ impl GhciStderr {
 
     async fn dispatch(&mut self, event: StderrEvent) -> miette::Result<()> {
         match event {
-            StderrEvent::Write(sender) => {
-                let res = self.write().await;
-                let _ = sender.send(());
-                res?;
-            }
             StderrEvent::Mode { mode, sender } => {
                 self.set_mode(sender, mode).await;
-            }
-            StderrEvent::SetCompilationSummary { summary, sender } => {
-                self.set_compilation_summary(sender, summary).await;
             }
             StderrEvent::GetBuffer { sender } => {
                 self.get_buffer(sender).await;
@@ -121,89 +84,16 @@ impl GhciStderr {
 
     #[instrument(skip(self), level = "trace")]
     async fn ingest_line(&mut self, line: String) {
-        // We might not have a buffer for some modes, e.g. `Internal`.
-        if let Some(buffer) = self.buffers.get_mut(&self.mode) {
-            buffer.push_str(&line);
-            buffer.push('\n');
-            self.has_unwritten_data = true;
-        }
         // Then write to our general buffer.
         self.buffer.push_str(&line);
         self.buffer.push('\n');
         eprintln!("{line}");
     }
 
-    #[instrument(skip_all, level = "debug")]
-    async fn write(&mut self) -> miette::Result<()> {
-        if !self.has_unwritten_data {
-            tracing::debug!("No new data, not writing");
-            return Ok(());
-        }
-
-        if let Some(path) = &self.error_path {
-            let file = File::create(path).await.into_diagnostic()?;
-            let mut writer = BufWriter::new(file);
-
-            if !self.compilation_summary.is_empty() {
-                tracing::debug!(%path, "Writing error log headline");
-                writer
-                    .write_all(self.compilation_summary.as_bytes())
-                    .await
-                    .into_diagnostic()?;
-                writer.write_all(b"\n").await.into_diagnostic()?;
-            }
-
-            for (mode, buffer) in &self.buffers {
-                tracing::debug!(%path, %mode, bytes = buffer.len(), "Writing error log");
-                writer
-                    .write_all(&strip_ansi_escapes::strip(buffer.as_bytes()))
-                    .await
-                    .into_diagnostic()?;
-            }
-
-            // This is load-bearing! If we don't properly flush/shutdown the handle, nothing gets
-            // written!
-            writer.shutdown().await.into_diagnostic()?;
-        }
-
-        self.has_unwritten_data = false;
-
-        Ok(())
-    }
-
     #[instrument(skip(self, sender), level = "trace")]
     async fn set_mode(&mut self, sender: oneshot::Sender<()>, mode: Mode) {
         self.mode = mode;
-
-        // Clear the buffer for the newly-selected mode.
-        //
-        // TODO: What if this deletes useful errors that don't get resurfaced?
-        // For example, a user adds a new module and `ghci` shows errors with that module but not
-        // previous compilation errors in different modules.
-        // Maybe analagous to the way warnings can get hidden because they're only surfaced during
-        // compilation of that particular module and aren't fatal.
-        if let Some(buffer) = self.buffers.get_mut(&self.mode) {
-            buffer.clear();
-        }
-
-        // Clear the general buffer.
         self.buffer.clear();
-
-        // If we're compiling, also clear the headline so we don't write a stale status/module
-        // count.
-        if mode == Mode::Compiling {
-            self.compilation_summary.clear();
-        }
-
-        let _ = sender.send(());
-    }
-
-    #[instrument(skip(self, sender), level = "debug")]
-    async fn set_compilation_summary(&mut self, sender: oneshot::Sender<()>, summary: String) {
-        if summary != self.compilation_summary {
-            self.compilation_summary = summary;
-            self.has_unwritten_data = true;
-        }
         let _ = sender.send(());
     }
 

--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -116,14 +116,6 @@ impl GhciStdout {
             .await?;
         tracing::debug!(data, "Synced with ghci");
 
-        // Tell the stderr stream to write the error log and then finish.
-        let (err_sender, err_receiver) = oneshot::channel();
-        let _ = self
-            .stderr_sender
-            .send(StderrEvent::Write(err_sender))
-            .await;
-        let _ = err_receiver.await;
-
         sentinel.finish();
         Ok(())
     }

--- a/test-harness/src/matcher.rs
+++ b/test-harness/src/matcher.rs
@@ -374,4 +374,31 @@ mod tests {
             ..event.clone()
         }));
     }
+
+    #[test]
+    fn test_matcher_in_span() {
+        assert!(Matcher::span_close()
+            .in_span("error_log_write")
+            .matches(&Event {
+                timestamp: "2023-09-12T18:06:04.677942Z".into(),
+                level: Level::DEBUG,
+                message: "close".into(),
+                fields: [
+                    ("message".into(), "close".into()),
+                    ("time.busy".into(), "206µs".into()),
+                    ("time.idle".into(), "246µs".into()),
+                ]
+                .into(),
+                target: "ghcid_ng::ghci::error_log".into(),
+                span: Some(Span {
+                    name: "error_log_write".into(),
+                    rest: [(
+                        "compilation_summary".into(),
+                        "Some(CompilationSummary { result: Ok, modules_loaded: 4 })".into()
+                    )]
+                    .into(),
+                }),
+                spans: vec![Span::new("on_action"), Span::new("reload"),]
+            }));
+    }
 }

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -25,9 +25,7 @@ async fn can_write_error_log() {
         .await
         .expect("ghcid-ng writes ghcid.txt");
     expect![[r#"
-        Ok, four modules loaded.
-        Warning: No remote package servers have been specified. Usually you would have
-        one specified in the config file.
+        All good (4 modules)
     "#]]
     .assert_eq(&error_contents);
 }
@@ -68,11 +66,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghcid-ng loads new modules");
 
     session
-        .get_log(
-            Matcher::span_close()
-                .in_span("write")
-                .in_module("ghcid_ng::ghci::stderr"),
-        )
+        .get_log(Matcher::span_close().in_span("error_log_write"))
         .await
         .expect("ghcid-ng writes ghcid.txt");
 
@@ -82,8 +76,6 @@ async fn can_write_error_log_compilation_errors() {
 
     let expected = match session.ghc_version() {
         Ghc90 | Ghc92 | Ghc94 => expect![[r#"
-            Failed, four modules loaded.
-
             src/My/Module.hs:3:11: error:
                 * Couldn't match type `[Char]' with `()'
                   Expected: ()
@@ -95,8 +87,6 @@ async fn can_write_error_log_compilation_errors() {
               |           ^^^^^^^^
         "#]],
         Ghc96 => expect![[r#"
-            Failed, four modules loaded.
-
             src/My/Module.hs:3:11: error: [GHC-83865]
                 * Couldn't match type `[Char]' with `()'
                   Expected: ()
@@ -121,11 +111,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghcid-ng reloads on changes");
 
     session
-        .get_log(
-            Matcher::span_close()
-                .in_span("write")
-                .in_module("ghcid_ng::ghci::stderr"),
-        )
+        .get_log(Matcher::span_close().in_span("error_log_write"))
         .await
         .expect("ghcid-ng writes ghcid.txt");
 
@@ -134,7 +120,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghcid-ng writes ghcid.txt");
 
     expect![[r#"
-        Ok, five modules loaded.
+        All good (5 modules)
     "#]]
     .assert_eq(&error_contents);
 }


### PR DESCRIPTION
The biggest user-facing change here is to replace the `Ok, 123 modules loaded.` "compilation summary" headline with `All good (123 modules)`; [the `ghcid` editor plugins are hard-coded to recognize this string.](https://github.com/ndmitchell/ghcid/blob/e2852979aa644c8fed92d46ab529d2c6c1c62b59/plugins/vscode/src/extension.ts#L79)

Previously, I had a rather clever system for the error log which would direct anything on stderr to the error log, divided up by what it was doing; a separate section for test output and compiler output. This is of dubious utility -- anyone who wants to see the test output can just look at the console, so the `--errors` output should be for tooling only. In the future, it might be nice to experiment with getting test failures in there too -- maybe we could reformat them to look like compiler errors?

This change wouldn't have been so big, but changing the way the error log is written to be purely a function of the parsed diagnostics meant it was easy to factor out into a new type, leaving the `GhciStderr` task stripped down and greatly simplified.

Also, I needed to write `Display` impls for the GHC diagnostics, which necessitated a new `GhcDiagnostic` type and lots of tests.

