### PR TITLE
Fix branch labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,8 @@
 ---
 # See: https://github.com/marketplace/actions/labeler
 patch:
-  - 'src/**/*.rs'
-  - 'data/**/*'
-  - 'Cargo.toml'
-  - 'Cargo.lock'
+  - 'ghcid-ng/src/**/*.rs'
+  - '**/Cargo.toml'
+  - '**/Cargo.lock'
+  - 'flake.nix'
+  - 'flake.lock'

--- a/test-harness-macro/Cargo.toml
+++ b/test-harness-macro/Cargo.toml
@@ -13,3 +13,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0.33"
 syn = { version = "2.0.29", features = ["full"] }
+
+# See: https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md
+[package.metadata.release]
+release = false

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -20,3 +20,7 @@ test-harness-macro = { path = "../test-harness-macro" }
 test_bin = "0.4.0"
 tokio = { version = "1.28.2", features = ["full", "tracing"] }
 tracing = "0.1.37"
+
+# See: https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md
+[package.metadata.release]
+release = false


### PR DESCRIPTION
This lets us label PRs as patch when they change source files.