### PR TITLE
More lifecycle hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "ghcid-ng"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aho-corasick",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ publish = false # Don't do `cargo publish`.
 # Define the root package: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
 [package]
 name = "ghcid-ng"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = [
     "Rebecca Turner <rebeccat@mercury.com>"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -144,6 +144,9 @@ pub struct HookOpts {
     pub after_startup_ghci: Vec<GhciCommand>,
 
     /// `ghci` commands to run before reloading `ghci`.
+    ///
+    /// These are run when modules are change on disk; this does not necessarily correspond to a
+    /// `:reload` command.
     #[arg(long, value_name = "GHCI_COMMAND")]
     pub before_reload_ghci: Vec<GhciCommand>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,10 +25,10 @@ pub struct Opts {
     #[arg(long, value_name = "SHELL_COMMAND")]
     pub command: Option<ClonableCommand>,
 
-    /// A `ghci` command which runs tests, like `TestMain.testMain`. If given, this command will be
+    /// `ghci` commands which runs tests, like `TestMain.testMain`. If given, these commands will be
     /// run after reloads.
     #[arg(long, value_name = "GHCI_COMMAND")]
-    pub test_ghci: Option<GhciCommand>,
+    pub test_ghci: Vec<GhciCommand>,
 
     /// Shell commands to run before starting or restarting `ghci`.
     ///
@@ -40,6 +40,14 @@ pub struct Opts {
     /// the command-line arguments for tests.
     #[arg(long, value_name = "GHCI_COMMAND")]
     pub after_startup_ghci: Vec<GhciCommand>,
+
+    /// `ghci` commands to run before reloading `ghci`.
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub before_reload_ghci: Vec<GhciCommand>,
+
+    /// `ghci` commands to run after reloading `ghci`.
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub after_reload_ghci: Vec<GhciCommand>,
 
     /// A file to write compilation errors to. This is analogous to `ghcid.txt`.
     #[arg(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,30 +25,6 @@ pub struct Opts {
     #[arg(long, value_name = "SHELL_COMMAND")]
     pub command: Option<ClonableCommand>,
 
-    /// `ghci` commands which runs tests, like `TestMain.testMain`. If given, these commands will be
-    /// run after reloads.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub test_ghci: Vec<GhciCommand>,
-
-    /// Shell commands to run before starting or restarting `ghci`.
-    ///
-    /// This can be used to regenerate `.cabal` files with `hpack`.
-    #[arg(long, value_name = "SHELL_COMMAND")]
-    pub before_startup_shell: Vec<ClonableCommand>,
-
-    /// `ghci` commands to run on startup. Use `:set args ...` in combination with `--test` to set
-    /// the command-line arguments for tests.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub after_startup_ghci: Vec<GhciCommand>,
-
-    /// `ghci` commands to run before reloading `ghci`.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub before_reload_ghci: Vec<GhciCommand>,
-
-    /// `ghci` commands to run after reloading `ghci`.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub after_reload_ghci: Vec<GhciCommand>,
-
     /// A file to write compilation errors to. This is analogous to `ghcid.txt`.
     #[arg(long)]
     pub errors: Option<Utf8PathBuf>,
@@ -59,6 +35,10 @@ pub struct Opts {
     /// and `<$ -}` and evaluates them after reloads.
     #[arg(long)]
     pub enable_eval: bool,
+
+    /// Lifecycle hooks and commands to run at various points.
+    #[command(flatten)]
+    pub hooks: HookOpts,
 
     /// Options to modify file watching.
     #[command(flatten)]
@@ -138,6 +118,55 @@ pub struct LoggingOpts {
     /// Path to write JSON logs to.
     #[arg(long, value_name = "PATH")]
     pub log_json: Option<Utf8PathBuf>,
+}
+
+/// Lifecycle hooks.
+///
+/// These are commands (mostly `ghci` commands) to run at various points in the `ghcid-ng`
+/// lifecycle.
+#[derive(Debug, Clone, clap::Args)]
+#[clap(next_help_heading = "Lifecycle hooks")]
+pub struct HookOpts {
+    /// `ghci` commands which runs tests, like `TestMain.testMain`. If given, these commands will be
+    /// run after reloads.
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub test_ghci: Vec<GhciCommand>,
+
+    /// Shell commands to run before starting or restarting `ghci`.
+    ///
+    /// This can be used to regenerate `.cabal` files with `hpack`.
+    #[arg(long, value_name = "SHELL_COMMAND")]
+    pub before_startup_shell: Vec<ClonableCommand>,
+
+    /// `ghci` commands to run on startup. Use `:set args ...` in combination with `--test` to set
+    /// the command-line arguments for tests.
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub after_startup_ghci: Vec<GhciCommand>,
+
+    /// `ghci` commands to run before reloading `ghci`.
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub before_reload_ghci: Vec<GhciCommand>,
+
+    /// `ghci` commands to run after reloading `ghci`.
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub after_reload_ghci: Vec<GhciCommand>,
+
+    /// `ghci` commands to run before restarting `ghci`.
+    ///
+    /// See `--after-restart-ghci` for more details.
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub before_restart_ghci: Vec<GhciCommand>,
+
+    /// `ghci` commands to run after restarting `ghci`.
+    ///
+    /// `ghci` cannot reload after files are deleted due to a bug, so `ghcid-ng` has to restart the
+    /// underlying `ghci` session when this happens. Note that the `--before-restart-ghci` and
+    /// `--after-restart-ghci` commands will therefore run in different `ghci` sessions without
+    /// shared context.
+    ///
+    /// See: https://gitlab.haskell.org/ghc/ghc/-/issues/9648
+    #[arg(long, value_name = "GHCI_COMMAND")]
+    pub after_restart_ghci: Vec<GhciCommand>,
 }
 
 impl Opts {

--- a/src/ghci/ghci_command.rs
+++ b/src/ghci/ghci_command.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::fmt::Display;
+use std::ops::Deref;
 
 /// A `ghci` command.
 ///
@@ -41,6 +42,14 @@ impl From<GhciCommand> for String {
 
 impl AsRef<str> for GhciCommand {
     fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for GhciCommand {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -85,8 +85,8 @@ pub struct GhciOpts {
     pub before_startup_shell: Vec<ClonableCommand>,
     /// `ghci` commands to run after starting or restarting `ghci`.
     pub after_startup_ghci: Vec<GhciCommand>,
-    /// `ghci` command which runs tests.
-    pub test_ghci: Option<GhciCommand>,
+    /// `ghci` commands which run tests.
+    pub test_ghci: Vec<GhciCommand>,
     /// Enable running eval commands in files.
     pub enable_eval: bool,
 }
@@ -399,7 +399,7 @@ impl Ghci {
     #[instrument(skip_all, level = "debug")]
     pub async fn test(&mut self) -> miette::Result<()> {
         self.stdin
-            .test(&mut self.stdout, self.opts.test_ghci.clone())
+            .test(&mut self.stdout, &self.opts.test_ghci)
             .await?;
         Ok(())
     }

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -81,18 +81,19 @@ impl GhciStdin {
     pub async fn test(
         &mut self,
         stdout: &mut GhciStdout,
-        test_command: Option<GhciCommand>,
+        test_commands: &[GhciCommand],
     ) -> miette::Result<()> {
-        if let Some(test_command) = test_command {
+        if test_commands.is_empty() {
+            tracing::debug!("No test command provided, not running tests");
+        }
+        for test_command in test_commands {
             self.set_mode(stdout, Mode::Testing).await?;
             tracing::debug!(command = %test_command, "Running user test command");
-            tracing::info!("Running tests");
+            tracing::info!("Running tests: {test_command}");
             let start_time = Instant::now();
             self.write_line(stdout, &format!("{test_command}\n"))
                 .await?;
             tracing::info!("Finished running tests in {:.2?}", start_time.elapsed());
-        } else {
-            tracing::debug!("No test command provided, not running tests");
         }
 
         Ok(())

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -46,6 +46,29 @@ impl GhciStdin {
         stdout.prompt(None).await
     }
 
+    /// Run a [`GhciCommand`].
+    ///
+    /// The command may be multiple lines.
+    #[instrument(skip(self, stdout), level = "debug")]
+    pub async fn run_command(
+        &mut self,
+        stdout: &mut GhciStdout,
+        command: &GhciCommand,
+    ) -> miette::Result<Vec<GhcMessage>> {
+        let mut ret = Vec::new();
+
+        for line in command.lines() {
+            self.stdin
+                .write_all(line.as_bytes())
+                .await
+                .into_diagnostic()?;
+            self.stdin.write_all(b"\n").await.into_diagnostic()?;
+            ret.extend(stdout.prompt(None).await?);
+        }
+
+        Ok(ret)
+    }
+
     #[instrument(skip(self, stdout), name = "stdin_initialize", level = "debug")]
     pub async fn initialize(
         &mut self,
@@ -64,8 +87,8 @@ impl GhciStdin {
         .await?;
 
         for command in setup_commands {
-            tracing::debug!(%command, "Running user intialization command");
-            self.write_line(stdout, &format!("{command}\n")).await?;
+            tracing::debug!(%command, "Running after-startup command");
+            self.run_command(stdout, command).await?;
         }
 
         Ok(())
@@ -86,13 +109,12 @@ impl GhciStdin {
         if test_commands.is_empty() {
             tracing::debug!("No test command provided, not running tests");
         }
+        self.set_mode(stdout, Mode::Testing).await?;
         for test_command in test_commands {
-            self.set_mode(stdout, Mode::Testing).await?;
             tracing::debug!(command = %test_command, "Running user test command");
             tracing::info!("Running tests: {test_command}");
             let start_time = Instant::now();
-            self.write_line(stdout, &format!("{test_command}\n"))
-                .await?;
+            self.run_command(stdout, test_command).await?;
             tracing::info!("Finished running tests in {:.2?}", start_time.elapsed());
         }
 
@@ -180,14 +202,7 @@ impl GhciStdin {
             .into_diagnostic()?;
         stdout.prompt(None).await?;
 
-        for line in command.as_ref().lines() {
-            self.stdin
-                .write_all(line.as_bytes())
-                .await
-                .into_diagnostic()?;
-            self.stdin.write_all(b"\n").await.into_diagnostic()?;
-            stdout.prompt(None).await?;
-        }
+        self.run_command(stdout, command).await?;
 
         self.stdin
             .write_all(format!(":module - *{module}\n").as_bytes())

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,0 +1,168 @@
+use test_harness::fs;
+use test_harness::test;
+use test_harness::GhcidNgBuilder;
+use test_harness::Matcher;
+
+/// Test that `ghcid-ng` can run its lifecycle hooks.
+///
+/// The strategy here is to set a bunch of hooks that print simple messages. We use multiple hooks
+/// just to test that it's allowed. Then we trigger the events that make the hooks run and confirm
+/// that the hooks run.
+#[test]
+async fn can_run_hooks() {
+    let mut session = GhcidNgBuilder::new("tests/data/simple")
+        .with_args([
+            "--after-startup-ghci",
+            "putStrLn \"after-startup-1\"",
+            "--after-startup-ghci",
+            "putStrLn \"after-startup-2\"",
+            "--before-reload-ghci",
+            "putStrLn \"before-reload-1\"",
+            "--before-reload-ghci",
+            "putStrLn \"before-reload-2\"",
+            "--after-reload-ghci",
+            "putStrLn \"after-reload-1\"",
+            "--after-reload-ghci",
+            "putStrLn \"after-reload-2\"",
+            "--before-restart-ghci",
+            "putStrLn \"before-restart-1\"",
+            "--before-restart-ghci",
+            "putStrLn \"before-restart-2\"",
+            "--after-restart-ghci",
+            "putStrLn \"after-restart-1\"",
+            "--after-restart-ghci",
+            "putStrLn \"after-restart-2\"",
+        ])
+        .start()
+        .await
+        .expect("ghcid-ng starts");
+
+    session
+        .assert_logged(
+            Matcher::message("Running after-startup command")
+                .with_field("command", "putStrLn \"after-startup-1\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^after-startup-1$"))
+        .await
+        .unwrap();
+
+    session
+        .assert_logged(
+            Matcher::message("Running after-startup command")
+                .with_field("command", "putStrLn \"after-startup-2\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^after-startup-2$"))
+        .await
+        .unwrap();
+
+    session.wait_until_ready().await.unwrap();
+
+    fs::touch(session.path("src/MyLib.hs")).await.unwrap();
+
+    // Before reload
+    session
+        .assert_logged(
+            Matcher::message("Running before-reload command")
+                .with_field("command", "putStrLn \"before-reload-1\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^before-reload-1$"))
+        .await
+        .unwrap();
+
+    session
+        .assert_logged(
+            Matcher::message("Running before-reload command")
+                .with_field("command", "putStrLn \"before-reload-2\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^before-reload-2$"))
+        .await
+        .unwrap();
+
+    // After reload
+    session
+        .assert_logged(
+            Matcher::message("Running after-reload command")
+                .with_field("command", "putStrLn \"after-reload-1\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^after-reload-1$"))
+        .await
+        .unwrap();
+
+    session
+        .assert_logged(
+            Matcher::message("Running after-reload command")
+                .with_field("command", "putStrLn \"after-reload-2\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^after-reload-2$"))
+        .await
+        .unwrap();
+
+    fs::remove(session.path("src/MyModule.hs")).await.unwrap();
+    // Before restart
+    session
+        .assert_logged(
+            Matcher::message("Running before-restart command")
+                .with_field("command", "putStrLn \"before-restart-1\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^before-restart-1$"))
+        .await
+        .unwrap();
+
+    session
+        .assert_logged(
+            Matcher::message("Running before-restart command")
+                .with_field("command", "putStrLn \"before-restart-2\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^before-restart-2$"))
+        .await
+        .unwrap();
+
+    // After restart
+    session
+        .assert_logged(
+            Matcher::message("Running after-restart command")
+                .with_field("command", "putStrLn \"after-restart-1\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^after-restart-1$"))
+        .await
+        .unwrap();
+
+    session
+        .assert_logged(
+            Matcher::message("Running after-restart command")
+                .with_field("command", "putStrLn \"after-restart-2\""),
+        )
+        .await
+        .unwrap();
+    session
+        .assert_logged(Matcher::message("Read line").with_field("line", "^after-restart-2$"))
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
This adds support for multiple test commands (`--test-ghci`) and before/after reload/restart hooks: `--before-reload-ghci`, `--after-reload-ghci`, `--before-restart-ghci`, and `--after-restart-ghci`. We may also consider before/after hooks for eval commands.