### PR TITLE
Allow custom prompts in `.ghci`

### DIFF
--- a/src/aho_corasick.rs
+++ b/src/aho_corasick.rs
@@ -11,6 +11,9 @@ pub trait AhoCorasickExt {
     /// Attempt to match at the start of the input.
     fn find_at_start(&self, input: &str) -> Option<Match>;
 
+    /// Attempt to match anywhere in the input.
+    fn find_anywhere(&self, input: &str) -> Option<Match>;
+
     /// Build a matcher from the given set of patterns, with anchored matching enabled (matching at
     /// the start of the string only).
     fn from_anchored_patterns(patterns: impl IntoIterator<Item = impl AsRef<[u8]>>) -> Self;
@@ -21,9 +24,13 @@ impl AhoCorasickExt for AhoCorasick {
         self.find(Input::new(input).anchored(Anchored::Yes))
     }
 
+    fn find_anywhere(&self, input: &str) -> Option<Match> {
+        self.find(Input::new(input).anchored(Anchored::No))
+    }
+
     fn from_anchored_patterns(patterns: impl IntoIterator<Item = impl AsRef<[u8]>>) -> Self {
         Self::builder()
-            .start_kind(StartKind::Anchored)
+            .start_kind(StartKind::Both)
             .build(patterns)
             .unwrap()
     }

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -252,13 +252,14 @@ impl Ghci {
         ret.stderr_handle = stderr;
 
         // Wait for the stdout job to start up.
-        let messages = ret.stdout.initialize().await?;
-        ret.process_ghc_messages(messages).await?;
+        ret.stdout.initialize().await?;
 
         // Perform start-of-session initialization.
-        ret.stdin
+        let messages = ret
+            .stdin
             .initialize(&mut ret.stdout, &ret.opts.hooks.after_startup_ghci)
             .await?;
+        ret.process_ghc_messages(messages).await?;
 
         // Sync up for any prompts.
         ret.sync().await?;

--- a/tests/dot_ghci.rs
+++ b/tests/dot_ghci.rs
@@ -1,0 +1,29 @@
+use test_harness::fs;
+use test_harness::test;
+use test_harness::GhcidNgBuilder;
+
+use indoc::indoc;
+
+/// Test that `ghcid-ng` can run with a custom prompt in `.ghci`.
+#[test]
+async fn can_run_with_custom_ghci_prompt() {
+    let mut session = GhcidNgBuilder::new("tests/data/simple")
+        .before_start(|project| async move {
+            fs::write(
+                project.join(".ghci"),
+                indoc!(
+                    r#"
+                    :set prompt "λ "
+                    :set prompt-cont "│ "
+                    "#
+                ),
+            )
+            .await?;
+            Ok(())
+        })
+        .start()
+        .await
+        .expect("ghcid-ng starts");
+
+    session.wait_until_ready().await.unwrap();
+}


### PR DESCRIPTION
Previously, `:set prompt` commands in `.ghci` configuration files would cause `ghcid-ng` to hang on start. This fixes that bug.