### PR TITLE
Gracefully exit when `ghci` exits

### DIFF
--- a/src/ghci/stderr.rs
+++ b/src/ghci/stderr.rs
@@ -65,8 +65,13 @@ impl GhciStderr {
                 Some(event) = self.receiver.recv() => {
                     self.dispatch(event).await?;
                 }
+                else => {
+                    // Graceful exit.
+                    break;
+                }
             }
         }
+        Ok(())
     }
 
     async fn dispatch(&mut self, event: StderrEvent) -> miette::Result<()> {


### PR DESCRIPTION
Note that this won't gracefully exit until a reload is triggered, though.