### PR TITLE
Housekeeping: Make most modules private

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -9,10 +9,6 @@ use std::process::Stdio;
 use miette::miette;
 use miette::IntoDiagnostic;
 use miette::WrapErr;
-use nix::sys::signal;
-use nix::sys::signal::Signal;
-use nix::unistd::Pid;
-use tokio::process::Child;
 use tokio::process::Command;
 
 /// Format a [`Command`] as a string, quoting arguments and program names with
@@ -45,27 +41,6 @@ pub fn from_string(shell_command: &str) -> miette::Result<ClonableCommand> {
             ..Default::default()
         }),
     }
-}
-
-/// Send a signal to a child process.
-pub fn send_signal(child: &Child, signal: Signal) -> miette::Result<()> {
-    signal::kill(
-        Pid::from_raw(
-            child
-                .id()
-                .ok_or_else(|| miette!("Command has no pid, likely because it has already exited"))?
-                .try_into()
-                .into_diagnostic()
-                .wrap_err("Failed to convert pid type")?,
-        ),
-        signal,
-    )
-    .into_diagnostic()
-}
-
-/// Partially-applied form of [`send_signal`].
-pub fn send_sigterm(child: &Child) -> miette::Result<()> {
-    send_signal(child, Signal::SIGTERM)
 }
 
 /// Like [`std::process::Stdio`], but it implements [`Clone`].

--- a/src/ghci/parse/module_set.rs
+++ b/src/ghci/parse/module_set.rs
@@ -34,16 +34,6 @@ impl ModuleSet {
         self.set.len()
     }
 
-    /// Determine if this set is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Remove all entries from this set, leaving it empty.
-    pub fn clear(&mut self) {
-        self.set.clear();
-    }
-
     /// Determine if a module with the given source path is contained in this module set.
     pub fn contains_source_path<P>(&self, path: &P) -> miette::Result<bool>
     where
@@ -51,23 +41,6 @@ impl ModuleSet {
         P: Hash + Eq + ?Sized,
     {
         Ok(self.set.contains(path))
-    }
-
-    /// Add a source path to this module set.
-    pub fn insert_source_path(&mut self, path: NormalPath) -> miette::Result<()> {
-        self.set.insert(path);
-        Ok(())
-    }
-
-    /// Remove a source path from this module set.
-    ///
-    /// Returns whether the path was present in the set.
-    pub fn remove_source_path<P>(&mut self, path: &P)
-    where
-        NormalPath: Borrow<P>,
-        P: Hash + Eq,
-    {
-        self.set.remove(path);
     }
 
     /// Iterate over the source paths in this module set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,25 +11,30 @@
 
 #![deny(missing_docs)]
 
-pub mod aho_corasick;
-pub mod buffers;
-pub mod clap;
+mod aho_corasick;
+mod buffers;
+mod clap;
 pub mod cli;
-pub mod command;
-pub mod event_filter;
+mod command;
+mod event_filter;
 mod format_bulleted_list;
-pub mod ghci;
-pub mod haskell_show;
-pub mod haskell_source_file;
-pub mod incremental_reader;
-pub mod lines;
-pub mod normal_path;
-pub mod sync_sentinel;
-pub mod textwrap;
-pub mod tracing;
-pub mod watcher;
+mod ghci;
+mod haskell_show;
+mod haskell_source_file;
+mod incremental_reader;
+mod normal_path;
+mod sync_sentinel;
+mod textwrap;
+mod tracing;
+mod watcher;
 
 pub(crate) use format_bulleted_list::format_bulleted_list;
+
+pub use ghci::Ghci;
+pub use ghci::GhciOpts;
+pub use tracing::TracingOpts;
+pub use watcher::Watcher;
+pub use watcher::WatcherOpts;
 
 #[cfg(test)]
 mod fake_reader;

--- a/src/lines.rs
+++ b/src/lines.rs
@@ -1,4 +1,0 @@
-//! The [`Lines`] type, a group of lines of text.
-
-/// A group of lines of text, represented as a list.
-pub type Lines = Vec<String>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,11 @@
 
 use clap::Parser;
 use ghcid_ng::cli;
-use ghcid_ng::ghci::Ghci;
-use ghcid_ng::ghci::GhciOpts;
-use ghcid_ng::tracing;
-use ghcid_ng::watcher::Watcher;
-use ghcid_ng::watcher::WatcherOpts;
+use ghcid_ng::Ghci;
+use ghcid_ng::GhciOpts;
+use ghcid_ng::TracingOpts;
+use ghcid_ng::Watcher;
+use ghcid_ng::WatcherOpts;
 use miette::IntoDiagnostic;
 use miette::WrapErr;
 
@@ -19,7 +19,7 @@ async fn main() -> miette::Result<()> {
     miette::set_panic_hook();
     let mut opts = cli::Opts::parse();
     opts.init()?;
-    tracing::TracingOpts::from_cli(&opts).install()?;
+    TracingOpts::from_cli(&opts).install()?;
 
     ::tracing::warn!(
         "This is a prerelease alpha version of `ghcid-ng`! Expect a rough user experience, and please report bugs or other issues to the #mighty-dux channel on Slack."


### PR DESCRIPTION
This gives us better dead code warnings, among other things.