### PR TITLE
Fix "modules defined in multiple files" bug when modules are renamed

### DIFF
--- a/src/ghci/parse/show_paths.rs
+++ b/src/ghci/parse/show_paths.rs
@@ -34,6 +34,7 @@ impl ShowPaths {
         if is_haskell_source_file(target_path) {
             // The target is already a path.
             if let Some(path) = self.target_path_to_path(target_path) {
+                tracing::trace!(%path, %target, "Target is path");
                 return Ok(path);
             }
         } else {
@@ -45,6 +46,7 @@ impl ShowPaths {
                 path.set_extension(haskell_source_extension);
 
                 if let Some(path) = self.target_path_to_path(&path) {
+                    tracing::trace!(%path, %target, "Found path for target");
                     return Ok(path);
                 }
             }

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -191,7 +191,7 @@ impl GhciStdin {
         stdout.show_paths().await
     }
 
-    #[instrument(skip(self, stdout), level = "debug")]
+    #[instrument(skip_all, level = "debug")]
     pub async fn show_targets(
         &mut self,
         stdout: &mut GhciStdout,

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -1,0 +1,45 @@
+use test_harness::fs;
+use test_harness::test;
+use test_harness::GhcidNg;
+use test_harness::Matcher;
+
+/// Test that `ghcid-ng` can restart correctly when modules are removed and added (i.e., renamed)
+/// at the same time.
+#[test]
+async fn can_compile_renamed_module() {
+    let mut session = GhcidNg::new("tests/data/simple")
+        .await
+        .expect("ghcid-ng starts");
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghcid-ng loads ghci");
+
+    let module_path = session.path("src/MyModule.hs");
+    let new_module_path = session.path("src/MyCoolModule.hs");
+    fs::rename(&module_path, &new_module_path).await.unwrap();
+
+    session
+        .wait_until_restart()
+        .await
+        .expect("ghcid-ng restarts on module move");
+
+    session
+        .assert_logged(Matcher::message("Compilation failed").in_span("reload"))
+        .await
+        .unwrap();
+
+    fs::replace(new_module_path, "module MyModule", "module MyCoolModule")
+        .await
+        .unwrap();
+
+    session
+        .wait_until_reload()
+        .await
+        .expect("ghcid-ng reloads on module change");
+
+    session
+        .assert_logged(Matcher::message("Compilation succeeded").in_span("reload"))
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
This fixes a "modules defined in multiple files" bug when a module is renamed. The rename is interpreted as one module being deleted (which triggers a restart) and one module being added (which triggers an `:add`).

The bug is that it would restart `ghci`, thereby loading the new module, and then attempt to `:add` the new module anyways, which would fail.